### PR TITLE
加固 APK 更新逻辑，增加了检查更新的入口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle
+.kotlin/
 /local.properties
 .DS_Store
 /build

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)
     implementation(libs.androidx.core.ktx)
+    testImplementation(kotlin("test-junit"))
 
     implementation(libs.zxing.android.embedded)
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/ahu/ahutong/MainActivity.kt
+++ b/app/src/main/java/com/ahu/ahutong/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.ahu.ahutong
 
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -37,6 +39,7 @@ import com.ahu.ahutong.ui.state.ScheduleViewModel
 import com.ahu.ahutong.ui.theme.AHUTheme
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
+import java.security.MessageDigest
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -95,7 +98,7 @@ class MainActivity : ComponentActivity() {
                             mainViewModel.showApkUpdateDialog.value = false
                         },
                         onCancel = {
-                            mainViewModel.showApkUpdateDialog.value = false
+                            mainViewModel.continueApkDownloadInBackground()
                             Toast.makeText(this@MainActivity, "已转到后台下载", Toast.LENGTH_SHORT).show()
                         }
                     )
@@ -230,6 +233,14 @@ class MainActivity : ComponentActivity() {
     private fun installApk(apkFile: File) {
         Log.i("ApkUpdate", "installApk called, file=${apkFile.absolutePath}")
 
+        validateApkBeforeInstall(apkFile)?.let { error ->
+            Log.w("ApkUpdate", "blocked APK install: $error")
+            mainViewModel.reportApkInstallError(error)
+            Toast.makeText(this, error, Toast.LENGTH_LONG).show()
+            apkFile.delete()
+            return
+        }
+
         val uri = FileProvider.getUriForFile(
             this,
             "${packageName}.fileprovider",
@@ -248,6 +259,110 @@ class MainActivity : ComponentActivity() {
         } catch (e: Exception) {
             Log.e("ApkUpdate", "start install activity failed", e)
             throw e
+        }
+    }
+
+    private fun validateApkBeforeInstall(apkFile: File): String? {
+        if (!apkFile.exists() || apkFile.length() <= 0L) {
+            return "安装包不存在或为空"
+        }
+
+        val canonicalApk = runCatching { apkFile.canonicalFile }.getOrElse {
+            return "安装包路径无效"
+        }
+        val trustedDirs = listOfNotNull(getExternalFilesDir(null), filesDir).mapNotNull {
+            runCatching { it.canonicalFile }.getOrNull()
+        }
+        val isInTrustedDir = trustedDirs.any { dir ->
+            canonicalApk.path == dir.path || canonicalApk.path.startsWith(dir.path + File.separator)
+        }
+        if (!isInTrustedDir) {
+            return "安装包位置不可信"
+        }
+
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            @Suppress("DEPRECATION")
+            PackageManager.GET_SIGNATURES
+        }
+
+        val archiveInfo = packageManager.getPackageArchiveInfo(canonicalApk.absolutePath, flags)
+            ?: return "安装包解析失败"
+        if (archiveInfo.packageName != packageName) {
+            return "安装包包名不匹配"
+        }
+
+        if (versionCodeOf(archiveInfo) <= currentVersionCode()) {
+            return "安装包版本不高于当前版本"
+        }
+
+        if (!hasMatchingSigningCertificate(archiveInfo, flags)) {
+            return "安装包签名与当前应用不一致"
+        }
+
+        return null
+    }
+
+    private fun hasMatchingSigningCertificate(archiveInfo: PackageInfo, flags: Int): Boolean {
+        val installedInfo = try {
+            packageManager.getPackageInfo(packageName, flags)
+        } catch (e: Exception) {
+            Log.w("ApkUpdate", "failed to read installed package signatures", e)
+            return false
+        }
+
+        val archiveSigners = signatureDigests(archiveInfo, includeHistory = false)
+        val installedSigners = signatureDigests(installedInfo, includeHistory = false)
+        if (archiveSigners.isEmpty() || installedSigners.isEmpty()) return false
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return archiveSigners == installedSigners
+        }
+
+        val archiveSigningInfo = archiveInfo.signingInfo ?: return false
+        val installedSigningInfo = installedInfo.signingInfo ?: return false
+        if (archiveSigningInfo.hasMultipleSigners() || installedSigningInfo.hasMultipleSigners()) {
+            return archiveSigners == installedSigners
+        }
+
+        val archiveHistory = signatureDigests(archiveInfo, includeHistory = true)
+        val installedHistory = signatureDigests(installedInfo, includeHistory = true)
+        return archiveSigners.any { it in installedHistory } ||
+            installedSigners.any { it in archiveHistory }
+    }
+
+    private fun signatureDigests(info: PackageInfo, includeHistory: Boolean): Set<String> {
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signingInfo = info.signingInfo ?: return emptySet()
+            if (includeHistory && !signingInfo.hasMultipleSigners()) {
+                signingInfo.signingCertificateHistory ?: signingInfo.apkContentsSigners
+            } else {
+                signingInfo.apkContentsSigners
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            info.signatures
+        } ?: return emptySet()
+
+        return signatures.map { signature ->
+            MessageDigest.getInstance("SHA-256")
+                .digest(signature.toByteArray())
+                .joinToString("") { "%02x".format(it) }
+        }.toSet()
+    }
+
+    private fun currentVersionCode(): Long {
+        val packageInfo = packageManager.getPackageInfo(packageName, 0)
+        return versionCodeOf(packageInfo)
+    }
+
+    private fun versionCodeOf(info: PackageInfo): Long {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
         }
     }
 

--- a/app/src/main/java/com/ahu/ahutong/data/server/AhuTong.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/AhuTong.kt
@@ -1,12 +1,11 @@
 package com.ahu.ahutong.data.server
 
 
+import com.ahu.ahutong.BuildConfig
 import com.ahu.ahutong.data.server.model.ApkUpdateInfo
 import com.ahu.ahutong.data.server.model.Captcha
-import okhttp3.Interceptor
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.ResponseBody
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -17,6 +16,7 @@ import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Streaming
 import retrofit2.http.Url
+import java.util.concurrent.TimeUnit
 
 interface AhuTong {
 
@@ -32,7 +32,7 @@ interface AhuTong {
 
     @Streaming
     @GET
-    suspend fun downloadByUrl(@Url fileUrl: String): ResponseBody
+    suspend fun downloadByUrl(@Url fileUrl: String): retrofit2.Response<ResponseBody>
 
 
     companion object {
@@ -41,8 +41,20 @@ interface AhuTong {
 
         val okHttpClient = OkHttpClient
             .Builder()
+            .connectTimeout(20, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .callTimeout(15, TimeUnit.MINUTES)
+            .retryOnConnectionFailure(true)
             .followRedirects(true)
             .followSslRedirects(true)
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "AHUTong/${BuildConfig.VERSION_NAME} (Android)")
+                    .header("Accept", "*/*")
+                    .build()
+                chain.proceed(request)
+            }
             .build()
 
 

--- a/app/src/main/java/com/ahu/ahutong/data/server/AhuTong.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/AhuTong.kt
@@ -57,11 +57,18 @@ interface AhuTong {
             }
             .build()
 
+        private val apkDownloadOkHttpClient = okHttpClient.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
 
-        val API = Retrofit.Builder()
+        private fun createApi(client: OkHttpClient) = Retrofit.Builder()
             .addConverterFactory(GsonConverterFactory.create())
-            .client(okHttpClient)
+            .client(client)
             .baseUrl(BASE_URL)
             .build().create(AhuTong::class.java)
+
+        val API = createApi(okHttpClient)
+        val APK_DOWNLOAD_API = createApi(apkDownloadOkHttpClient)
     }
 }

--- a/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
@@ -5,6 +5,7 @@ import java.net.URI
 
 object ApkUpdatePolicy {
     const val MAX_APK_BYTES: Long = 200L * 1024L * 1024L
+    const val MAX_DOWNLOAD_REDIRECTS: Int = 5
     private const val ERROR_NO_UPDATE = "No APK update is available"
     private const val ERROR_NOT_NEWER = "Remote APK version is not newer"
 
@@ -23,9 +24,18 @@ object ApkUpdatePolicy {
             return Result.failure(IllegalArgumentException(ERROR_NO_UPDATE))
         }
 
+        if (info.versionCode <= 0) {
+            return Result.failure(IllegalArgumentException("Remote APK version is invalid"))
+        }
+
         if (info.versionCode <= currentVersionCode) {
             return Result.failure(IllegalArgumentException(ERROR_NOT_NEWER))
         }
+
+        val versionName = info.versionName?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: info.versionCode.toString()
+        val changelog = info.changelog?.trim().orEmpty()
 
         val sha256 = normalizeSha256(info.sha256).getOrElse {
             return Result.failure(it)
@@ -37,17 +47,32 @@ object ApkUpdatePolicy {
 
         return Result.success(
             ValidatedUpdate(
-                info = info.copy(url = downloadUrl, sha256 = sha256),
+                info = info.copy(
+                    versionName = versionName,
+                    changelog = changelog,
+                    url = downloadUrl,
+                    sha256 = sha256
+                ),
                 downloadUrl = downloadUrl,
                 sha256 = sha256
             )
         )
     }
 
-    fun validateDownloadUrl(rawUrl: String?): Result<String> {
+    fun validateDownloadUrl(rawUrl: String?, baseUrl: String? = null): Result<String> {
         val url = rawUrl?.trim()
         if (url.isNullOrEmpty()) {
             return Result.failure(IllegalArgumentException("APK download URL is empty"))
+        }
+
+        val baseUri = if (baseUrl.isNullOrBlank()) {
+            baseDownloadUri
+        } else {
+            try {
+                URI(baseUrl)
+            } catch (e: Exception) {
+                return Result.failure(IllegalArgumentException("APK download base URL is invalid", e))
+            }
         }
 
         val parsedUri = try {
@@ -55,7 +80,7 @@ object ApkUpdatePolicy {
         } catch (e: Exception) {
             return Result.failure(IllegalArgumentException("APK download URL is invalid", e))
         }
-        val uri = if (parsedUri.isAbsolute) parsedUri else baseDownloadUri.resolve(parsedUri)
+        val uri = if (parsedUri.isAbsolute) parsedUri else baseUri.resolve(parsedUri)
 
         if (!uri.scheme.equals("https", ignoreCase = true)) {
             return Result.failure(IllegalArgumentException("APK download URL must use HTTPS"))

--- a/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
@@ -1,0 +1,102 @@
+package com.ahu.ahutong.data.server
+
+import com.ahu.ahutong.data.server.model.ApkUpdateInfo
+import java.net.URI
+
+object ApkUpdatePolicy {
+    const val MAX_APK_BYTES: Long = 200L * 1024L * 1024L
+    private const val ERROR_NO_UPDATE = "No APK update is available"
+    private const val ERROR_NOT_NEWER = "Remote APK version is not newer"
+
+    private val sha256Regex = Regex("^[0-9a-fA-F]{64}$")
+    private val baseDownloadUri = URI("https://openahu.org/")
+    private val trustedDownloadHosts = setOf("openahu.org", "www.openahu.org")
+
+    data class ValidatedUpdate(
+        val info: ApkUpdateInfo,
+        val downloadUrl: String,
+        val sha256: String
+    )
+
+    fun validate(info: ApkUpdateInfo, currentVersionCode: Int): Result<ValidatedUpdate> {
+        if (info.update == false) {
+            return Result.failure(IllegalArgumentException(ERROR_NO_UPDATE))
+        }
+
+        if (info.versionCode <= currentVersionCode) {
+            return Result.failure(IllegalArgumentException(ERROR_NOT_NEWER))
+        }
+
+        val sha256 = normalizeSha256(info.sha256).getOrElse {
+            return Result.failure(it)
+        }
+
+        val downloadUrl = validateDownloadUrl(info.url).getOrElse {
+            return Result.failure(it)
+        }
+
+        return Result.success(
+            ValidatedUpdate(
+                info = info.copy(url = downloadUrl, sha256 = sha256),
+                downloadUrl = downloadUrl,
+                sha256 = sha256
+            )
+        )
+    }
+
+    fun validateDownloadUrl(rawUrl: String?): Result<String> {
+        val url = rawUrl?.trim()
+        if (url.isNullOrEmpty()) {
+            return Result.failure(IllegalArgumentException("APK download URL is empty"))
+        }
+
+        val parsedUri = try {
+            URI(url)
+        } catch (e: Exception) {
+            return Result.failure(IllegalArgumentException("APK download URL is invalid", e))
+        }
+        val uri = if (parsedUri.isAbsolute) parsedUri else baseDownloadUri.resolve(parsedUri)
+
+        if (!uri.scheme.equals("https", ignoreCase = true)) {
+            return Result.failure(IllegalArgumentException("APK download URL must use HTTPS"))
+        }
+
+        if (uri.userInfo != null) {
+            return Result.failure(IllegalArgumentException("APK download URL must not contain user info"))
+        }
+
+        if (uri.fragment != null) {
+            return Result.failure(IllegalArgumentException("APK download URL must not contain fragments"))
+        }
+
+        val host = uri.host?.lowercase()
+        if (host == null || host !in trustedDownloadHosts) {
+            return Result.failure(IllegalArgumentException("APK download host is not trusted"))
+        }
+
+        val path = uri.rawPath.orEmpty()
+        if (path.isBlank() || path == "/") {
+            return Result.failure(IllegalArgumentException("APK download URL path is empty"))
+        }
+
+        return Result.success(uri.toASCIIString())
+    }
+
+    fun normalizeSha256(rawSha256: String?): Result<String> {
+        val sha256 = rawSha256?.trim()
+        if (sha256.isNullOrEmpty()) {
+            return Result.failure(IllegalArgumentException("APK SHA-256 is required"))
+        }
+
+        if (!sha256Regex.matches(sha256)) {
+            return Result.failure(IllegalArgumentException("APK SHA-256 must be 64 hex characters"))
+        }
+
+        return Result.success(sha256.lowercase())
+    }
+
+    fun isNoUpdateFailure(error: Throwable): Boolean {
+        if (error !is IllegalArgumentException) return false
+        return error.message == ERROR_NO_UPDATE || error.message == ERROR_NOT_NEWER
+    }
+}

--- a/app/src/main/java/com/ahu/ahutong/data/server/model/ApkUpdateInfo.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/model/ApkUpdateInfo.kt
@@ -5,10 +5,10 @@ import androidx.annotation.Keep
 @Keep
 data class ApkUpdateInfo(
     val update: Boolean? = null,
-    val force: Boolean,
-    val versionCode: Int,
-    val versionName: String,
-    val changelog: String,
+    val force: Boolean = false,
+    val versionCode: Int = 0,
+    val versionName: String? = null,
+    val changelog: String? = null,
     val url: String? = null,
     val sha256: String? = null,
     val signature: String? = null,

--- a/app/src/main/java/com/ahu/ahutong/data/server/model/ApkUpdateInfo.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/model/ApkUpdateInfo.kt
@@ -4,7 +4,7 @@ import androidx.annotation.Keep
 
 @Keep
 data class ApkUpdateInfo(
-    val update: Boolean = false,
+    val update: Boolean? = null,
     val force: Boolean,
     val versionCode: Int,
     val versionName: String,

--- a/app/src/main/java/com/ahu/ahutong/notification/CourseLiveUpdateHelper.kt
+++ b/app/src/main/java/com/ahu/ahutong/notification/CourseLiveUpdateHelper.kt
@@ -1,6 +1,7 @@
 package com.ahu.ahutong.notification
 
 import android.app.AlarmManager
+import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -15,12 +16,15 @@ import com.ahu.ahutong.notification.model.CourseReminderPayload
 object CourseLiveUpdateHelper {
     private const val LIVE_NOTIFICATION_ID = 4096
     private const val LIVE_UPDATE_REQUEST_CODE = 4097
+    private const val LIVE_DISMISS_REQUEST_CODE = 4098
     private const val ONE_MINUTE_MS = 60_000L
 
     fun showLiveUpdate(
         context: Context,
         payload: CourseReminderPayload
     ): Boolean {
+        if (!CourseReminderCapability.isAndroid16Plus()) return false
+
         val courseStartAtMillis = payload.courseStartAtMillis ?: return false
         val remainingDurationMs = courseStartAtMillis - System.currentTimeMillis()
         val remainingMinutes = calculateRemainingMinutes(remainingDurationMs)
@@ -33,6 +37,7 @@ object CourseLiveUpdateHelper {
         val countdownText = buildCountdownText(remainingMinutes)
         val collapsedText = buildCollapsedText(payload, countdownText)
         val expandedText = buildExpandedText(payload, countdownText)
+        CourseReminderScheduler.createNotificationChannel(context)
         val notification = NotificationCompat.Builder(context, CourseReminderScheduler.CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher_round)
             .setContentTitle(payload.courseName)
@@ -50,7 +55,10 @@ object CourseLiveUpdateHelper {
             .setRequestPromotedOngoing(true)
             .setShortCriticalText(buildChipText(remainingMinutes))
             .setContentIntent(buildContentIntent(context, payload.notificationId))
+            .setDeleteIntent(buildDismissPendingIntent(context))
             .build()
+
+        if (!hasPromotableCharacteristics(notification)) return false
 
         NotificationManagerCompat.from(context).notify(LIVE_NOTIFICATION_ID, notification)
         return true
@@ -107,6 +115,18 @@ object CourseLiveUpdateHelper {
             )
     }
 
+    private fun buildDismissPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, CourseReminderReceiver::class.java).apply {
+            action = CourseReminderReceiver.ACTION_LIVE_COUNTDOWN_DISMISSED
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            LIVE_DISMISS_REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
     private fun buildUpdatePendingIntent(
         context: Context,
         payload: CourseReminderPayload?
@@ -142,6 +162,11 @@ object CourseLiveUpdateHelper {
                 pendingIntent
             )
         }
+    }
+
+    private fun hasPromotableCharacteristics(notification: Notification): Boolean {
+        if (Build.VERSION.SDK_INT < 36) return false
+        return notification.hasPromotableCharacteristics()
     }
 
     private fun calculateRemainingMinutes(

--- a/app/src/main/java/com/ahu/ahutong/notification/CourseReminderReceiver.kt
+++ b/app/src/main/java/com/ahu/ahutong/notification/CourseReminderReceiver.kt
@@ -7,6 +7,11 @@ import com.ahu.ahutong.notification.model.CourseReminderPayload
 
 class CourseReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_LIVE_COUNTDOWN_DISMISSED) {
+            CourseLiveUpdateHelper.cancelScheduledUpdate(context)
+            return
+        }
+
         val payload = CourseReminderPayload.fromIntent(intent) ?: return
         when (intent.action) {
             ACTION_REMIND -> {
@@ -37,5 +42,7 @@ class CourseReminderReceiver : BroadcastReceiver() {
         const val ACTION_REMIND = "com.ahu.ahutong.notification.ACTION_REMIND_COURSE"
         const val ACTION_UPDATE_LIVE_COUNTDOWN =
             "com.ahu.ahutong.notification.ACTION_UPDATE_LIVE_COUNTDOWN"
+        const val ACTION_LIVE_COUNTDOWN_DISMISSED =
+            "com.ahu.ahutong.notification.ACTION_LIVE_COUNTDOWN_DISMISSED"
     }
 }

--- a/app/src/main/java/com/ahu/ahutong/sdk/RustSDK.kt
+++ b/app/src/main/java/com/ahu/ahutong/sdk/RustSDK.kt
@@ -41,6 +41,7 @@ object RustSDK {
 
     private const val TAG_HOTUPDATE = "HotUpdate"
     private const val LIB_NAME = "libahutong_rs.so"
+    private val SHA256_HEX_REGEX = Regex("^[0-9a-fA-F]{64}$")
     private var isLoaded = false
     private val scope = kotlinx.coroutines.CoroutineScope(Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
 
@@ -65,7 +66,10 @@ object RustSDK {
         onHotUpdateSuccess: (() -> Unit)? = null,
         onHotUpdateFinished: (() -> Unit)? = null
     ){
-        if (isLoaded) return
+        if (isLoaded) {
+            onHotUpdateFinished?.invoke()
+            return
+        }
 
         try {
             // Check for App Update to prevent using outdated hot-update lib
@@ -314,6 +318,19 @@ object RustSDK {
         expectSha256Hex: String,
         signatureBase64: String
     ): Boolean {
+        if (!isHttpsUrl(urlStr)) {
+            Log.w(TAG_HOTUPDATE, "reject hotUpdate download: non-HTTPS url")
+            return false
+        }
+        if (!SHA256_HEX_REGEX.matches(expectSha256Hex)) {
+            Log.w(TAG_HOTUPDATE, "reject hotUpdate download: invalid sha256")
+            return false
+        }
+        if (signatureBase64.isBlank()) {
+            Log.w(TAG_HOTUPDATE, "reject hotUpdate download: empty signature")
+            return false
+        }
+
         // 使用与 loadLibrary 一致的路径获取方式
         val libDir = context.getDir("jniLibs", Context.MODE_PRIVATE)
         val tempFile = File(libDir, "$LIB_NAME.tmp")
@@ -364,8 +381,8 @@ object RustSDK {
                 return false
             }
 
-            targetFile.setReadable(true, false)
-            targetFile.setExecutable(true, false)
+            targetFile.setReadable(true, true)
+            targetFile.setExecutable(true, true)
 
             Log.i(TAG_HOTUPDATE, "hotUpdate success! Saved to: ${targetFile.absolutePath}. take effect on the next startup")
             return true
@@ -374,6 +391,12 @@ object RustSDK {
             tempFile.delete()
             return false
         }
+    }
+
+    private fun isHttpsUrl(urlStr: String): Boolean {
+        return runCatching {
+            URL(urlStr).protocol.equals("https", ignoreCase = true)
+        }.getOrDefault(false)
     }
 
     /**
@@ -548,6 +571,9 @@ object RustSDK {
         val urlStr = "https://$serverIp/download/xiaoli.jpg"
         return try {
             val conn = URL(urlStr).openConnection()
+            conn.connectTimeout = 10_000
+            conn.readTimeout = 10_000
+            conn.useCaches = false
             if (conn is javax.net.ssl.HttpsURLConnection) {
                 conn.hostnameVerifier = javax.net.ssl.HostnameVerifier { hostname, session ->
                     if (hostname == serverIp) true else javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/ApkUpdateDialog.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/ApkUpdateDialog.kt
@@ -61,7 +61,7 @@ fun ApkUpdateDialog(
         },
         title = {
             Text(
-                text = "发现新版本 ${info.versionName}",
+                text = "发现新版本 ${info.versionName ?: info.versionCode}",
                 fontWeight = FontWeight.Bold,
                 style = MaterialTheme.typography.headlineSmall,
                 color = contentColor
@@ -85,7 +85,7 @@ fun ApkUpdateDialog(
                 )
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(
-                    text = info.changelog.ifBlank { "暂无更新说明" },
+                    text = info.changelog?.ifBlank { "暂无更新说明" } ?: "暂无更新说明",
                     style = MaterialTheme.typography.bodyMedium,
                     color = contentColor
                 )

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/Settings.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/Settings.kt
@@ -90,7 +90,11 @@ fun Settings(
             aboutViewModel.tipState.value = null;
         }
 
-        runCatching { AhuTong.API.getApkUpdateInfo().changelog }
+        runCatching {
+            AhuTong.API.getApkUpdateInfo().changelog
+                ?.ifBlank { "暂无更新说明" }
+                ?: "暂无更新说明"
+        }
             .onSuccess { updateLog = it }
             .onFailure {
                 updateLog = "获取失败"

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/Settings.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/Settings.kt
@@ -9,7 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Login
 import androidx.compose.material.icons.outlined.PeopleOutline
 import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material.icons.outlined.Update
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -109,6 +111,30 @@ fun Settings(
             modifier = Modifier.padding(24.dp, 32.dp),
             style = MaterialTheme.typography.headlineLarge
         )
+        var count by remember { mutableStateOf(0) }
+        var lastClickTime by remember { mutableStateOf(0L) }
+        val clickTimes: Int = 8
+        val interval: Long = 1000
+        val checkUpdate = {
+            mainViewModel.checkApkUpdateManually(context) { message ->
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
+        }
+        val onAppCardClick = {
+            val now = System.currentTimeMillis()
+            if (now - lastClickTime > interval) {
+                count = 1
+            } else {
+                count++
+            }
+            lastClickTime = now
+
+            if (count >= clickTimes) {
+                count = 0
+                navController.navigate("debug")
+            }
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -118,30 +144,11 @@ fun Settings(
                 .padding(24.dp, 16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            var count by remember { mutableStateOf(0) }
-            var lastClickTime by remember { mutableStateOf(0L) }
-            val clickTimes: Int = 8
-            val interval: Long = 1000
-
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
-                ) {
-                    val now = System.currentTimeMillis()
-                    if (now - lastClickTime > interval) {
-                        count = 1
-                    } else {
-                        count++
-                    }
-                    lastClickTime = now
-
-                    if (count >= clickTimes) {
-                        count = 0
-                        navController.navigate("debug")
-                    }
+                modifier = Modifier.pointerInput(onAppCardClick) {
+                    detectTapGestures { onAppCardClick() }
                 }
             ) {
                 Image(
@@ -321,15 +328,15 @@ fun Settings(
                 onClick = { isClearCacheDialogShown = true }
             )
             SettingItem(
+                label = stringResource(id = R.string.check_update),
+                icon = Icons.Outlined.Update,
+                onClick = { checkUpdate() }
+            )
+            SettingItem(
                 label = stringResource(id = R.string.update_intro),
                 icon = Icons.Outlined.Article,
                 onClick = { isUpdateLogDialogShown = true }
             )
-//            SettingItem(
-//                label = stringResource(id = R.string.check_update),
-//                icon = Icons.Outlined.Update,
-//                onClick = { aboutViewModel.checkForUpdates() }
-//            )
         }
     }
     if (isClearCacheDialogShown) {

--- a/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.ahu.ahutong.BuildConfig
 import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.data.server.AhuTong
+import com.ahu.ahutong.data.server.ApkUpdatePolicy
 import com.ahu.ahutong.data.server.model.ApkUpdateInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,7 +18,9 @@ import kotlinx.coroutines.withContext
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import java.io.File
+import java.io.BufferedOutputStream
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.security.MessageDigest
 
@@ -25,6 +28,9 @@ class MainViewModel : ViewModel() {
 
     companion object {
         private val apkDownloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        private const val DOWNLOAD_BUFFER_SIZE = 64 * 1024
+        private const val PROGRESS_MIN_INTERVAL_MS = 1_000L
+        private const val PROGRESS_MIN_DELTA = 0.01f
     }
 
     // App update UI states
@@ -34,11 +40,13 @@ class MainViewModel : ViewModel() {
     var apkProgress = mutableStateOf<Float?>(null)
     var apkErrorText = mutableStateOf<String?>(null)
     var downloadedApkFile = mutableStateOf<File?>(null)
+    var apkUpdateChecking = mutableStateOf(false)
     /** 本地已存在目标版本 APK，可直接安装 */
     var apkLocalReady = mutableStateOf(false)
 
     private var apkDownloadJob: Job? = null
     private var installAfterApkDownload = false
+    private var showDialogWhenApkDownloadCompletes = false
 
     private val apkFileRegex = Regex("""^update-(\d+)\.apk$""")
 
@@ -68,24 +76,19 @@ class MainViewModel : ViewModel() {
 
         // 2. 从云端获取最新版本信息
         val info = runCatching { AhuTong.API.getApkUpdateInfo() }.getOrNull() ?: return@withContext
-        if (info.versionCode <= BuildConfig.VERSION_CODE) return@withContext
+        val update = ApkUpdatePolicy.validate(info, BuildConfig.VERSION_CODE).getOrElse {
+            Log.w("ApkUpdate", "ignore invalid APK update metadata: ${it.message}")
+            return@withContext
+        }
 
         // 3. 检查本地是否已有该版本的 APK，并校验 sha256
-        val localApk = File(dir, "update-${info.versionCode}.apk")
+        val localApk = File(dir, "update-${update.info.versionCode}.apk")
         val localReady = if (localApk.exists() && localApk.length() > 0) {
-            if (!info.sha256.isNullOrEmpty()) {
-                val localHash = runCatching { sha256Of(localApk) }.getOrNull()
-                val match = localHash.equals(info.sha256, ignoreCase = true)
-                if (!match) {
-                    Log.w("ApkUpdate", "local APK sha256 mismatch, expected=${info.sha256}, got=$localHash, deleting")
-                    localApk.delete()
-                }
-                match
-            } else true
+            verifyCachedApk(localApk, update.sha256, "local APK")
         } else false
 
         withContext(Dispatchers.Main) {
-            apkUpdateInfo.value = info
+            apkUpdateInfo.value = update.info
             apkErrorText.value = null
             apkLocalReady.value = localReady
             showApkUpdateDialog.value = true
@@ -114,10 +117,10 @@ class MainViewModel : ViewModel() {
      * 直接安装本地已缓存的 APK（用户点击"安装"按钮）
      */
     fun installLocalApk(context: Context) {
-        val info = apkUpdateInfo.value ?: return
+        val update = selectedValidatedUpdate() ?: return
         viewModelScope.launch(Dispatchers.IO) {
             val dir = context.getExternalFilesDir(null) ?: context.filesDir
-            val localApk = File(dir, "update-${info.versionCode}.apk")
+            val localApk = File(dir, "update-${update.info.versionCode}.apk")
             if (!localApk.exists() || localApk.length() <= 0) {
                 withContext(Dispatchers.Main) {
                     apkLocalReady.value = false
@@ -125,18 +128,12 @@ class MainViewModel : ViewModel() {
                 }
                 return@launch
             }
-            // 校验 sha256
-            if (!info.sha256.isNullOrEmpty()) {
-                val localHash = runCatching { sha256Of(localApk) }.getOrNull()
-                if (!localHash.equals(info.sha256, ignoreCase = true)) {
-                    Log.w("ApkUpdate", "install: sha256 mismatch, deleting corrupt APK")
-                    localApk.delete()
-                    withContext(Dispatchers.Main) {
-                        apkLocalReady.value = false
-                        apkErrorText.value = "本地文件已损坏，请重新下载"
-                    }
-                    return@launch
+            if (!verifyCachedApk(localApk, update.sha256, "install APK")) {
+                withContext(Dispatchers.Main) {
+                    apkLocalReady.value = false
+                    apkErrorText.value = "本地文件已损坏，请重新下载"
                 }
+                return@launch
             }
             withContext(Dispatchers.Main) {
                 downloadedApkFile.value = localApk
@@ -149,8 +146,11 @@ class MainViewModel : ViewModel() {
         forceRedownload: Boolean = false,
         installAfterDownload: Boolean = false
     ) {
-        val info = apkUpdateInfo.value ?: return
+        val update = selectedValidatedUpdate() ?: return
         if (apkDownloading.value) return
+        apkDownloading.value = true
+        apkErrorText.value = null
+        apkProgress.value = null
         installAfterApkDownload = installAfterDownload
         val appContext = context.applicationContext
 
@@ -158,82 +158,106 @@ class MainViewModel : ViewModel() {
             // 检查本地是否已存在该版本 APK 并校验完整性（IO 安全）
             apkDownloadScope.launch {
                 val dir = appContext.getExternalFilesDir(null) ?: appContext.filesDir
-                val existingApk = File(dir, "update-${info.versionCode}.apk")
+                val existingApk = File(dir, "update-${update.info.versionCode}.apk")
                 if (existingApk.exists() && existingApk.length() > 0) {
-                    // 校验 sha256
-                    if (!info.sha256.isNullOrEmpty()) {
-                        val localHash = runCatching { sha256Of(existingApk) }.getOrNull()
-                        if (!localHash.equals(info.sha256, ignoreCase = true)) {
-                            Log.w("ApkUpdate", "cached APK sha256 mismatch, deleting")
-                            existingApk.delete()
-                            withContext(Dispatchers.Main) {
-                                apkLocalReady.value = false
-                                doApkDownload(appContext, info)
-                            }
-                            return@launch
+                    if (!verifyCachedApk(existingApk, update.sha256, "cached APK")) {
+                        withContext(Dispatchers.Main) {
+                            apkLocalReady.value = false
+                            doApkDownload(appContext, update)
                         }
+                        return@launch
                     }
                     Log.i("ApkUpdate", "APK already exists locally: ${existingApk.absolutePath}")
                     withContext(Dispatchers.Main) {
+                        apkDownloading.value = false
+                        apkProgress.value = null
                         apkLocalReady.value = true
                         if (installAfterApkDownload) {
                             downloadedApkFile.value = existingApk
+                        } else if (showDialogWhenApkDownloadCompletes) {
+                            showDialogWhenApkDownloadCompletes = false
+                            showApkUpdateDialog.value = true
                         }
                     }
                     return@launch
                 }
-                withContext(Dispatchers.Main) { doApkDownload(appContext, info) }
+                withContext(Dispatchers.Main) { doApkDownload(appContext, update) }
             }
         } else {
             // 强制重新下载：先删除本地缓存
             apkDownloadScope.launch {
                 val dir = appContext.getExternalFilesDir(null) ?: appContext.filesDir
-                val existingApk = File(dir, "update-${info.versionCode}.apk")
+                val existingApk = File(dir, "update-${update.info.versionCode}.apk")
                 existingApk.delete()
                 withContext(Dispatchers.Main) {
                     apkLocalReady.value = false
-                    doApkDownload(appContext, info)
+                    doApkDownload(appContext, update)
                 }
             }
         }
     }
 
-    private fun doApkDownload(context: Context, info: ApkUpdateInfo) {
-        if (info.url.isNullOrEmpty()) {
-            apkErrorText.value = "下载地址为空"
-            return
-        }
+    private fun doApkDownload(context: Context, update: ApkUpdatePolicy.ValidatedUpdate) {
         apkDownloading.value = true
         apkErrorText.value = null
         apkProgress.value = null
 
         apkDownloadJob = apkDownloadScope.launch {
+            var tempFile: File? = null
             try {
-                val body = AhuTong.API.downloadByUrl(info.url!!)
+                val response = AhuTong.API.downloadByUrl(update.downloadUrl)
+                val finalUrl = response.raw().request.url.toString()
+                ApkUpdatePolicy.validateDownloadUrl(finalUrl).getOrElse {
+                    throw SecurityException("下载重定向到不受信任地址")
+                }
+
+                if (!response.isSuccessful) {
+                    throw IOException("下载失败：HTTP ${response.code()}")
+                }
+
+                val body = response.body() ?: throw IOException("下载内容为空")
                 val total = body.contentLength()
+                if (total > ApkUpdatePolicy.MAX_APK_BYTES) {
+                    throw IOException("安装包过大，请稍后重试")
+                }
+
                 withContext(Dispatchers.Main) {
                     apkProgress.value = if (total > 0) 0f else null
                 }
 
                 val dir = context.getExternalFilesDir(null) ?: context.filesDir
-                val outFile = File(dir, "update-${info.versionCode}.apk")
+                val outFile = File(dir, "update-${update.info.versionCode}.apk")
+                val partFile = File(dir, "${outFile.name}.part")
+                tempFile = partFile
+                partFile.delete()
 
                 var completed = 0L
                 var lastEmit = System.currentTimeMillis()
+                var lastProgress = 0f
+                if (total > 0) {
+                    emitApkProgress(0f)
+                }
                 body.byteStream().use { input: InputStream ->
-                    FileOutputStream(outFile).use { output ->
-                        val buffer = ByteArray(8 * 1024)
+                    BufferedOutputStream(FileOutputStream(partFile), DOWNLOAD_BUFFER_SIZE).use { output ->
+                        val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
                         var read = input.read(buffer)
                         while (read >= 0) {
                             output.write(buffer, 0, read)
                             completed += read
+                            if (completed > ApkUpdatePolicy.MAX_APK_BYTES) {
+                                throw IOException("安装包超过大小限制")
+                            }
                             if (total > 0) {
                                 val now = System.currentTimeMillis()
-                                if (now - lastEmit >= 100 || completed == total) {
-                                    val prog = (completed.toDouble() / total.toDouble()).coerceIn(0.0, 1.0)
-                                    withContext(Dispatchers.Main) {
-                                        apkProgress.value = prog.toFloat()
-                                    }
+                                val prog = (completed.toDouble() / total.toDouble())
+                                    .coerceIn(0.0, 1.0)
+                                    .toFloat()
+                                if (prog - lastProgress >= PROGRESS_MIN_DELTA ||
+                                    now - lastEmit >= PROGRESS_MIN_INTERVAL_MS ||
+                                    completed == total
+                                ) {
+                                    emitApkProgress(prog)
+                                    lastProgress = prog
                                     lastEmit = now
                                 }
                             }
@@ -245,28 +269,32 @@ class MainViewModel : ViewModel() {
 
                 // 校验下载完整性
                 if (total > 0 && completed != total) {
-                    outFile.delete()
-                    withContext(Dispatchers.Main) {
-                        apkDownloading.value = false
-                        apkProgress.value = null
-                        apkErrorText.value = "下载不完整（${completed}/${total}），请重试"
-                    }
-                    return@launch
+                    throw IOException("下载不完整（${completed}/${total}），请重试")
+                }
+
+                val downloadedFile = partFile
+                if (!downloadedFile.exists() || downloadedFile.length() <= 0L) {
+                    throw IOException("下载内容为空")
                 }
 
                 // 校验 sha256
-                if (!info.sha256.isNullOrEmpty()) {
-                    val hash = runCatching { sha256Of(outFile) }.getOrNull()
-                    if (!hash.equals(info.sha256, ignoreCase = true)) {
-                        Log.w("ApkUpdate", "download sha256 mismatch: expected=${info.sha256}, got=$hash")
-                        outFile.delete()
-                        withContext(Dispatchers.Main) {
-                            apkDownloading.value = false
-                            apkProgress.value = null
-                            apkErrorText.value = "文件校验失败，请重试"
+                val hash = runCatching { sha256Of(downloadedFile) }.getOrNull()
+                if (!hash.equals(update.sha256, ignoreCase = true)) {
+                    Log.w("ApkUpdate", "download sha256 mismatch: expected=${update.sha256}, got=$hash")
+                    throw SecurityException("文件校验失败，请重试")
+                }
+
+                if (outFile.exists() && !outFile.delete()) {
+                    throw IOException("无法替换旧安装包")
+                }
+
+                if (!downloadedFile.renameTo(outFile)) {
+                    downloadedFile.inputStream().use { input ->
+                        FileOutputStream(outFile).use { output ->
+                            input.copyTo(output)
                         }
-                        return@launch
                     }
+                    downloadedFile.delete()
                 }
 
                 withContext(Dispatchers.Main) {
@@ -275,16 +303,125 @@ class MainViewModel : ViewModel() {
                     apkLocalReady.value = true
                     if (installAfterApkDownload) {
                         downloadedApkFile.value = outFile
+                    } else if (showDialogWhenApkDownloadCompletes) {
+                        showDialogWhenApkDownloadCompletes = false
+                        showApkUpdateDialog.value = true
                     }
                 }
             } catch (e: Exception) {
+                tempFile?.delete()
                 withContext(Dispatchers.Main) {
                     apkDownloading.value = false
                     apkProgress.value = null
                     apkErrorText.value = e.message ?: "下载失败"
+                    if (showDialogWhenApkDownloadCompletes) {
+                        showDialogWhenApkDownloadCompletes = false
+                        showApkUpdateDialog.value = true
+                    }
                 }
             }
         }
+    }
+
+    private suspend fun emitApkProgress(progress: Float) {
+        withContext(Dispatchers.Main.immediate) {
+            apkProgress.value = progress.coerceIn(0f, 1f)
+        }
+    }
+
+    fun continueApkDownloadInBackground() {
+        if (apkDownloading.value) {
+            showDialogWhenApkDownloadCompletes = true
+        }
+        showApkUpdateDialog.value = false
+    }
+
+    fun checkApkUpdateManually(
+        context: Context,
+        onResult: (String) -> Unit
+    ) {
+        if (apkUpdateChecking.value) {
+            onResult("正在检查更新")
+            return
+        }
+
+        apkUpdateChecking.value = true
+        val appContext = context.applicationContext
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val resultText = try {
+                val dir = appContext.getExternalFilesDir(null) ?: appContext.filesDir
+                cleanStaleApks(dir)
+
+                val info = AhuTong.API.getApkUpdateInfo()
+                val update = ApkUpdatePolicy.validate(info, BuildConfig.VERSION_CODE).getOrElse { error ->
+                    return@launch finishManualUpdateCheck(
+                        if (ApkUpdatePolicy.isNoUpdateFailure(error)) {
+                            "已是最新版本"
+                        } else {
+                            "检查更新失败：${error.message ?: "更新信息无效"}"
+                        },
+                        onResult
+                    )
+                }
+
+                val localApk = File(dir, "update-${update.info.versionCode}.apk")
+                val localReady = if (localApk.exists() && localApk.length() > 0L) {
+                    verifyCachedApk(localApk, update.sha256, "manual check local APK")
+                } else {
+                    false
+                }
+
+                withContext(Dispatchers.Main) {
+                    apkUpdateInfo.value = update.info
+                    apkErrorText.value = null
+                    apkLocalReady.value = localReady
+                    showApkUpdateDialog.value = true
+                }
+
+                "发现新版本 ${update.info.versionName}"
+            } catch (e: Exception) {
+                Log.w("ApkUpdate", "manual update check failed", e)
+                "检查更新失败：${e.message ?: "请稍后重试"}"
+            }
+
+            finishManualUpdateCheck(resultText, onResult)
+        }
+    }
+
+    private suspend fun finishManualUpdateCheck(
+        resultText: String,
+        onResult: (String) -> Unit
+    ) {
+        withContext(Dispatchers.Main) {
+            apkUpdateChecking.value = false
+            onResult(resultText)
+        }
+    }
+
+    private fun selectedValidatedUpdate(): ApkUpdatePolicy.ValidatedUpdate? {
+        val info = apkUpdateInfo.value ?: return null
+        return ApkUpdatePolicy.validate(info, BuildConfig.VERSION_CODE).getOrElse {
+            apkErrorText.value = it.message ?: "更新信息校验失败"
+            apkLocalReady.value = false
+            Log.w("ApkUpdate", "invalid APK update metadata: ${it.message}")
+            null
+        }
+    }
+
+    private fun verifyCachedApk(file: File, expectedSha256: String, label: String): Boolean {
+        val hash = runCatching { sha256Of(file) }.getOrNull()
+        val match = hash.equals(expectedSha256, ignoreCase = true)
+        if (!match) {
+            Log.w("ApkUpdate", "$label sha256 mismatch, expected=$expectedSha256, got=$hash, deleting")
+            file.delete()
+        }
+        return match
+    }
+
+    fun reportApkInstallError(message: String) {
+        apkLocalReady.value = false
+        apkErrorText.value = message
     }
 
     fun markInstallHandled() {

--- a/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
+import okhttp3.ResponseBody
+import retrofit2.Response
 import java.io.File
 import java.io.BufferedOutputStream
 import java.io.FileOutputStream
@@ -205,19 +207,20 @@ class MainViewModel : ViewModel() {
         apkDownloadJob = apkDownloadScope.launch {
             var tempFile: File? = null
             try {
-                val response = AhuTong.API.downloadByUrl(update.downloadUrl)
-                val finalUrl = response.raw().request.url.toString()
-                ApkUpdatePolicy.validateDownloadUrl(finalUrl).getOrElse {
-                    throw SecurityException("下载重定向到不受信任地址")
-                }
-
+                val response = openApkDownloadResponse(update.downloadUrl)
                 if (!response.isSuccessful) {
+                    closeDownloadResponse(response)
                     throw IOException("下载失败：HTTP ${response.code()}")
                 }
 
-                val body = response.body() ?: throw IOException("下载内容为空")
+                val body = response.body() ?: run {
+                    closeDownloadResponse(response)
+                    throw IOException("下载内容为空")
+                }
+
                 val total = body.contentLength()
                 if (total > ApkUpdatePolicy.MAX_APK_BYTES) {
+                    body.close()
                     throw IOException("安装包过大，请稍后重试")
                 }
 
@@ -237,33 +240,35 @@ class MainViewModel : ViewModel() {
                 if (total > 0) {
                     emitApkProgress(0f)
                 }
-                body.byteStream().use { input: InputStream ->
-                    BufferedOutputStream(FileOutputStream(partFile), DOWNLOAD_BUFFER_SIZE).use { output ->
-                        val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                        var read = input.read(buffer)
-                        while (read >= 0) {
-                            output.write(buffer, 0, read)
-                            completed += read
-                            if (completed > ApkUpdatePolicy.MAX_APK_BYTES) {
-                                throw IOException("安装包超过大小限制")
-                            }
-                            if (total > 0) {
-                                val now = System.currentTimeMillis()
-                                val prog = (completed.toDouble() / total.toDouble())
-                                    .coerceIn(0.0, 1.0)
-                                    .toFloat()
-                                if (prog - lastProgress >= PROGRESS_MIN_DELTA ||
-                                    now - lastEmit >= PROGRESS_MIN_INTERVAL_MS ||
-                                    completed == total
-                                ) {
-                                    emitApkProgress(prog)
-                                    lastProgress = prog
-                                    lastEmit = now
+                body.use { responseBody ->
+                    responseBody.byteStream().use { input: InputStream ->
+                        BufferedOutputStream(FileOutputStream(partFile), DOWNLOAD_BUFFER_SIZE).use { output ->
+                            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+                            var read = input.read(buffer)
+                            while (read >= 0) {
+                                output.write(buffer, 0, read)
+                                completed += read
+                                if (completed > ApkUpdatePolicy.MAX_APK_BYTES) {
+                                    throw IOException("安装包超过大小限制")
                                 }
+                                if (total > 0) {
+                                    val now = System.currentTimeMillis()
+                                    val prog = (completed.toDouble() / total.toDouble())
+                                        .coerceIn(0.0, 1.0)
+                                        .toFloat()
+                                    if (prog - lastProgress >= PROGRESS_MIN_DELTA ||
+                                        now - lastEmit >= PROGRESS_MIN_INTERVAL_MS ||
+                                        completed == total
+                                    ) {
+                                        emitApkProgress(prog)
+                                        lastProgress = prog
+                                        lastEmit = now
+                                    }
+                                }
+                                read = input.read(buffer)
                             }
-                            read = input.read(buffer)
+                            output.flush()
                         }
-                        output.flush()
                     }
                 }
 
@@ -284,18 +289,7 @@ class MainViewModel : ViewModel() {
                     throw SecurityException("文件校验失败，请重试")
                 }
 
-                if (outFile.exists() && !outFile.delete()) {
-                    throw IOException("无法替换旧安装包")
-                }
-
-                if (!downloadedFile.renameTo(outFile)) {
-                    downloadedFile.inputStream().use { input ->
-                        FileOutputStream(outFile).use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                    downloadedFile.delete()
-                }
+                replaceDownloadedApk(downloadedFile, outFile, update.sha256)
 
                 withContext(Dispatchers.Main) {
                     apkDownloading.value = false
@@ -320,6 +314,63 @@ class MainViewModel : ViewModel() {
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun openApkDownloadResponse(initialUrl: String): Response<ResponseBody> {
+        var currentUrl = initialUrl
+        repeat(ApkUpdatePolicy.MAX_DOWNLOAD_REDIRECTS + 1) { redirectCount ->
+            val response = AhuTong.APK_DOWNLOAD_API.downloadByUrl(currentUrl)
+            val finalUrl = response.raw().request.url.toString()
+            ApkUpdatePolicy.validateDownloadUrl(finalUrl).getOrElse {
+                closeDownloadResponse(response)
+                throw SecurityException("下载地址不受信任")
+            }
+
+            val code = response.code()
+            if (code in 300..399) {
+                val location = response.headers()["Location"]
+                closeDownloadResponse(response)
+                if (location.isNullOrBlank()) {
+                    throw IOException("下载重定向地址为空")
+                }
+                if (redirectCount >= ApkUpdatePolicy.MAX_DOWNLOAD_REDIRECTS) {
+                    throw IOException("下载重定向次数过多")
+                }
+                currentUrl = ApkUpdatePolicy.validateDownloadUrl(location, finalUrl).getOrElse {
+                    throw SecurityException("下载重定向到不受信任地址")
+                }
+                return@repeat
+            }
+
+            return response
+        }
+        throw IOException("下载重定向次数过多")
+    }
+
+    private fun closeDownloadResponse(response: Response<ResponseBody>) {
+        response.body()?.close()
+        response.errorBody()?.close()
+    }
+
+    private fun replaceDownloadedApk(partFile: File, outFile: File, expectedSha256: String) {
+        if (outFile.exists() && !outFile.delete()) {
+            throw IOException("无法替换旧安装包")
+        }
+
+        if (!partFile.renameTo(outFile)) {
+            partFile.inputStream().use { input ->
+                FileOutputStream(outFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            if (!partFile.delete()) {
+                Log.w("ApkUpdate", "failed to delete temporary APK: ${partFile.name}")
+            }
+        }
+
+        if (!verifyCachedApk(outFile, expectedSha256, "downloaded APK")) {
+            throw SecurityException("文件校验失败，请重试")
         }
     }
 

--- a/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
+++ b/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
@@ -32,8 +32,27 @@ class ApkUpdatePolicyTest {
     }
 
     @Test
+    fun validateNormalizesMissingDisplayFields() {
+        val result = ApkUpdatePolicy.validate(
+            updateInfo(versionName = null, changelog = null),
+            currentVersionCode = 1
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("2", result.getOrThrow().info.versionName)
+        assertEquals("", result.getOrThrow().info.changelog)
+    }
+
+    @Test
     fun validateRejectsExplicitDisabledUpdate() {
         val result = ApkUpdatePolicy.validate(updateInfo(update = false), currentVersionCode = 1)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateRejectsInvalidRemoteVersion() {
+        val result = ApkUpdatePolicy.validate(updateInfo(versionCode = 0), currentVersionCode = 1)
 
         assertTrue(result.isFailure)
     }
@@ -70,6 +89,27 @@ class ApkUpdatePolicyTest {
     }
 
     @Test
+    fun validateResolvesRedirectLocationAgainstCurrentDownloadUrl() {
+        val result = ApkUpdatePolicy.validateDownloadUrl(
+            rawUrl = "next.apk",
+            baseUrl = "https://openahu.org/download/ahutong.apk"
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://openahu.org/download/next.apk", result.getOrThrow())
+    }
+
+    @Test
+    fun validateRejectsRedirectLocationToUntrustedHost() {
+        val result = ApkUpdatePolicy.validateDownloadUrl(
+            rawUrl = "//example.com/download/app.apk",
+            baseUrl = "https://openahu.org/download/ahutong.apk"
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
     fun validateRejectsNonNewerVersion() {
         val result = ApkUpdatePolicy.validate(updateInfo(versionCode = 1), currentVersionCode = 1)
 
@@ -79,14 +119,16 @@ class ApkUpdatePolicyTest {
     private fun updateInfo(
         update: Boolean? = true,
         versionCode: Int = 2,
+        versionName: String? = "2.0.0",
+        changelog: String? = "Fixes",
         url: String? = "https://openahu.org/download/app.apk",
         sha256: String? = this.sha256
     ) = ApkUpdateInfo(
         update = update,
         force = false,
         versionCode = versionCode,
-        versionName = "2.0.0",
-        changelog = "Fixes",
+        versionName = versionName,
+        changelog = changelog,
         url = url,
         sha256 = sha256,
         signature = null,

--- a/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
+++ b/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
@@ -1,0 +1,96 @@
+package com.ahu.ahutong.data.server
+
+import com.ahu.ahutong.data.server.model.ApkUpdateInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ApkUpdatePolicyTest {
+    private val sha256 = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+
+    @Test
+    fun validateAcceptsTrustedHttpsUpdateWithSha256() {
+        val result = ApkUpdatePolicy.validate(updateInfo(), currentVersionCode = 1)
+
+        assertTrue(result.isSuccess)
+        assertEquals(sha256.lowercase(), result.getOrThrow().sha256)
+        assertEquals("https://openahu.org/download/app.apk", result.getOrThrow().downloadUrl)
+    }
+
+    @Test
+    fun validateRejectsMissingSha256() {
+        val result = ApkUpdatePolicy.validate(updateInfo(sha256 = null), currentVersionCode = 1)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateAcceptsMissingUpdateFlagWhenVersionIsNewer() {
+        val result = ApkUpdatePolicy.validate(updateInfo(update = null), currentVersionCode = 1)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun validateRejectsExplicitDisabledUpdate() {
+        val result = ApkUpdatePolicy.validate(updateInfo(update = false), currentVersionCode = 1)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateResolvesTrustedRelativeDownloadUrl() {
+        val result = ApkUpdatePolicy.validate(
+            updateInfo(url = "/download/app.apk"),
+            currentVersionCode = 1
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://openahu.org/download/app.apk", result.getOrThrow().downloadUrl)
+    }
+
+    @Test
+    fun validateRejectsHttpDownloadUrl() {
+        val result = ApkUpdatePolicy.validate(
+            updateInfo(url = "http://openahu.org/download/app.apk"),
+            currentVersionCode = 1
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateRejectsUntrustedDownloadHost() {
+        val result = ApkUpdatePolicy.validate(
+            updateInfo(url = "https://example.com/download/app.apk"),
+            currentVersionCode = 1
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateRejectsNonNewerVersion() {
+        val result = ApkUpdatePolicy.validate(updateInfo(versionCode = 1), currentVersionCode = 1)
+
+        assertTrue(result.isFailure)
+    }
+
+    private fun updateInfo(
+        update: Boolean? = true,
+        versionCode: Int = 2,
+        url: String? = "https://openahu.org/download/app.apk",
+        sha256: String? = this.sha256
+    ) = ApkUpdateInfo(
+        update = update,
+        force = false,
+        versionCode = versionCode,
+        versionName = "2.0.0",
+        changelog = "Fixes",
+        url = url,
+        sha256 = sha256,
+        signature = null,
+        alg = null,
+        note = null
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,15 @@ pluginManagement {
         }
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.aliyun.com/repository/google") {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        maven("https://maven.aliyun.com/repository/gradle-plugin")
+        maven("https://maven.aliyun.com/repository/public")
     }
 }
 dependencyResolutionManagement {
@@ -17,6 +26,9 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://jitpack.io")
+        maven("https://maven.aliyun.com/repository/google")
+        maven("https://maven.aliyun.com/repository/central")
+        maven("https://maven.aliyun.com/repository/public")
     }
 }
 


### PR DESCRIPTION
- 为 APK 下载单独配置 Retrofit/OkHttp client，关闭自动重定向，改由客户端显式处理跳转。
- 新增 APK 下载重定向校验：
  - 限制最大重定向次数
  - 每次跳转都校验 HTTPS 与可信 host
  - 支持相对 `Location` 基于当前下载 URL 解析
  - 正确关闭非最终响应体，避免资源泄漏
- 强化 APK 更新元数据校验：
  - 拒绝非法远端版本号
  - 规范化 `versionName` 和 `changelog`
  - 兼容服务端缺省/空更新展示字段
- 优化 APK 文件替换流程：
  - 下载后移动/复制为正式 APK
  - 替换完成后再次校验 SHA-256
  - 清理临时文件失败时记录日志
- 更新更新弹窗和更新日志读取逻辑，避免 `versionName` / `changelog` 为空时崩溃或展示异常。
- 补充 APK 更新策略单元测试，覆盖字段规范化、非法版本号、相对重定向解析和不可信重定向 host。
构建测试通过
<img width="601" height="135" alt="image" src="https://github.com/user-attachments/assets/53fd3348-9768-447f-9e7a-3df338907f15" />
