### PR TITLE
新增了一个更新源的镜像源

### DIFF
--- a/app/src/main/java/com/ahu/ahutong/MainActivity.kt
+++ b/app/src/main/java/com/ahu/ahutong/MainActivity.kt
@@ -29,6 +29,7 @@ import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.ext.launchSafe
 import com.ahu.ahutong.sdk.LocalServiceClient
 import com.ahu.ahutong.sdk.RustSDK
+import com.ahu.ahutong.ui.component.ApkMirrorSourceDialog
 import com.ahu.ahutong.ui.component.ApkUpdateDialog
 import com.ahu.ahutong.ui.screen.Main
 import com.ahu.ahutong.ui.state.AboutViewModel
@@ -100,6 +101,16 @@ class MainActivity : ComponentActivity() {
                         onCancel = {
                             mainViewModel.continueApkDownloadInBackground()
                             Toast.makeText(this@MainActivity, "已转到后台下载", Toast.LENGTH_SHORT).show()
+                        }
+                    )
+                }
+                if (mainViewModel.showApkMirrorPrompt.value) {
+                    ApkMirrorSourceDialog(
+                        onUseMirror = {
+                            mainViewModel.switchApkDownloadToMirror(this@MainActivity)
+                        },
+                        onKeepOriginal = {
+                            mainViewModel.keepPrimaryApkDownload()
                         }
                     )
                 }

--- a/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/server/ApkUpdatePolicy.kt
@@ -6,12 +6,13 @@ import java.net.URI
 object ApkUpdatePolicy {
     const val MAX_APK_BYTES: Long = 200L * 1024L * 1024L
     const val MAX_DOWNLOAD_REDIRECTS: Int = 5
+    const val MIRROR_DOWNLOAD_HOST: String = "openahu-ahutong-cn.muxyang.com"
     private const val ERROR_NO_UPDATE = "No APK update is available"
     private const val ERROR_NOT_NEWER = "Remote APK version is not newer"
 
     private val sha256Regex = Regex("^[0-9a-fA-F]{64}$")
     private val baseDownloadUri = URI("https://openahu.org/")
-    private val trustedDownloadHosts = setOf("openahu.org", "www.openahu.org")
+    private val primaryDownloadHosts = setOf("openahu.org", "www.openahu.org")
 
     data class ValidatedUpdate(
         val info: ApkUpdateInfo,
@@ -59,7 +60,11 @@ object ApkUpdatePolicy {
         )
     }
 
-    fun validateDownloadUrl(rawUrl: String?, baseUrl: String? = null): Result<String> {
+    fun validateDownloadUrl(
+        rawUrl: String?,
+        baseUrl: String? = null,
+        allowMirrorHost: Boolean = false
+    ): Result<String> {
         val url = rawUrl?.trim()
         if (url.isNullOrEmpty()) {
             return Result.failure(IllegalArgumentException("APK download URL is empty"))
@@ -94,6 +99,11 @@ object ApkUpdatePolicy {
             return Result.failure(IllegalArgumentException("APK download URL must not contain fragments"))
         }
 
+        val trustedDownloadHosts = if (allowMirrorHost) {
+            primaryDownloadHosts + MIRROR_DOWNLOAD_HOST
+        } else {
+            primaryDownloadHosts
+        }
         val host = uri.host?.lowercase()
         if (host == null || host !in trustedDownloadHosts) {
             return Result.failure(IllegalArgumentException("APK download host is not trusted"))
@@ -105,6 +115,17 @@ object ApkUpdatePolicy {
         }
 
         return Result.success(uri.toASCIIString())
+    }
+
+    fun mirrorDownloadUrl(primaryDownloadUrl: String): Result<String> {
+        val trustedPrimaryUrl = validateDownloadUrl(primaryDownloadUrl).getOrElse {
+            return Result.failure(it)
+        }
+        val uri = URI(trustedPrimaryUrl)
+        val rawPath = uri.rawPath.orEmpty()
+        val rawQuery = uri.rawQuery?.let { "?$it" }.orEmpty()
+        val mirrorUrl = "https://$MIRROR_DOWNLOAD_HOST$rawPath$rawQuery"
+        return validateDownloadUrl(mirrorUrl, allowMirrorHost = true)
     }
 
     fun normalizeSha256(rawSha256: String?): Result<String> {

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/ApkUpdateDialog.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/ApkUpdateDialog.kt
@@ -186,3 +186,62 @@ fun ApkUpdateDialog(
         }
     )
 }
+
+@Composable
+fun ApkMirrorSourceDialog(
+    onUseMirror: () -> Unit,
+    onKeepOriginal: () -> Unit,
+) {
+    val contentColor = 10.n1 withNight 90.n1
+    val containerColor = 100.n1 withNight 20.n1
+
+    AlertDialog(
+        onDismissRequest = onKeepOriginal,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+        title = {
+            Text(
+                text = "下载较慢",
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
+                color = contentColor
+            )
+        },
+        text = {
+            Text(
+                text = "当前下载超过 5 秒仍未达到 30%，是否切换到镜像源继续下载？文件校验仍使用官方源提供的信息。",
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        },
+        shape = SmoothRoundedCornerShape(32.dp),
+        containerColor = containerColor,
+        confirmButton = {
+            FilledTonalButton(
+                onClick = onUseMirror,
+                modifier = Modifier.height(56.dp),
+                shape = SmoothRoundedCornerShape(16.dp),
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = 90.a1 withNight 85.a1,
+                    contentColor = 0.n1
+                )
+            ) {
+                Text(
+                    text = "使用镜像源",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onKeepOriginal,
+                modifier = Modifier.height(56.dp),
+            ) {
+                Text("继续原下载", color = contentColor)
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/MainViewModel.kt
@@ -9,10 +9,13 @@ import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.data.server.AhuTong
 import com.ahu.ahutong.data.server.ApkUpdatePolicy
 import com.ahu.ahutong.data.server.model.ApkUpdateInfo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.util.Log
@@ -25,6 +28,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicLong
 
 class MainViewModel : ViewModel() {
 
@@ -33,6 +37,8 @@ class MainViewModel : ViewModel() {
         private const val DOWNLOAD_BUFFER_SIZE = 64 * 1024
         private const val PROGRESS_MIN_INTERVAL_MS = 1_000L
         private const val PROGRESS_MIN_DELTA = 0.01f
+        private const val MIRROR_PROMPT_DELAY_MS = 5_000L
+        private const val MIRROR_PROMPT_PROGRESS_THRESHOLD = 0.30f
     }
 
     // App update UI states
@@ -43,6 +49,8 @@ class MainViewModel : ViewModel() {
     var apkErrorText = mutableStateOf<String?>(null)
     var downloadedApkFile = mutableStateOf<File?>(null)
     var apkUpdateChecking = mutableStateOf(false)
+    var showApkMirrorPrompt = mutableStateOf(false)
+    private val apkUsingMirrorSource = mutableStateOf(false)
     /** 本地已存在目标版本 APK，可直接安装 */
     var apkLocalReady = mutableStateOf(false)
 
@@ -153,6 +161,8 @@ class MainViewModel : ViewModel() {
         apkDownloading.value = true
         apkErrorText.value = null
         apkProgress.value = null
+        showApkMirrorPrompt.value = false
+        apkUsingMirrorSource.value = false
         installAfterApkDownload = installAfterDownload
         val appContext = context.applicationContext
 
@@ -199,15 +209,54 @@ class MainViewModel : ViewModel() {
         }
     }
 
-    private fun doApkDownload(context: Context, update: ApkUpdatePolicy.ValidatedUpdate) {
+    private fun doApkDownload(
+        context: Context,
+        update: ApkUpdatePolicy.ValidatedUpdate,
+        useMirrorSource: Boolean = false
+    ) {
         apkDownloading.value = true
         apkErrorText.value = null
         apkProgress.value = null
+        showApkMirrorPrompt.value = false
+        apkUsingMirrorSource.value = useMirrorSource
 
         apkDownloadJob = apkDownloadScope.launch {
             var tempFile: File? = null
+            val completedBytes = AtomicLong(0L)
+            val totalBytes = AtomicLong(-1L)
+            var mirrorPromptJob: Job? = null
             try {
-                val response = openApkDownloadResponse(update.downloadUrl)
+                val downloadUrl = if (useMirrorSource) {
+                    ApkUpdatePolicy.mirrorDownloadUrl(update.downloadUrl).getOrElse {
+                        throw SecurityException("镜像下载地址无效")
+                    }
+                } else {
+                    update.downloadUrl
+                }
+
+                if (!useMirrorSource) {
+                    mirrorPromptJob = launch {
+                        delay(MIRROR_PROMPT_DELAY_MS)
+                        val totalForPrompt = totalBytes.get()
+                        val progressForPrompt = if (totalForPrompt > 0L) {
+                            completedBytes.get().toDouble() / totalForPrompt.toDouble()
+                        } else {
+                            0.0
+                        }
+                        if (progressForPrompt < MIRROR_PROMPT_PROGRESS_THRESHOLD) {
+                            withContext(Dispatchers.Main.immediate) {
+                                if (apkDownloading.value &&
+                                    !apkUsingMirrorSource.value &&
+                                    !showApkMirrorPrompt.value
+                                ) {
+                                    showApkMirrorPrompt.value = true
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val response = openApkDownloadResponse(downloadUrl, allowMirrorHost = useMirrorSource)
                 if (!response.isSuccessful) {
                     closeDownloadResponse(response)
                     throw IOException("下载失败：HTTP ${response.code()}")
@@ -219,6 +268,7 @@ class MainViewModel : ViewModel() {
                 }
 
                 val total = body.contentLength()
+                totalBytes.set(total)
                 if (total > ApkUpdatePolicy.MAX_APK_BYTES) {
                     body.close()
                     throw IOException("安装包过大，请稍后重试")
@@ -248,6 +298,7 @@ class MainViewModel : ViewModel() {
                             while (read >= 0) {
                                 output.write(buffer, 0, read)
                                 completed += read
+                                completedBytes.set(completed)
                                 if (completed > ApkUpdatePolicy.MAX_APK_BYTES) {
                                     throw IOException("安装包超过大小限制")
                                 }
@@ -294,6 +345,8 @@ class MainViewModel : ViewModel() {
                 withContext(Dispatchers.Main) {
                     apkDownloading.value = false
                     apkProgress.value = null
+                    showApkMirrorPrompt.value = false
+                    apkUsingMirrorSource.value = false
                     apkLocalReady.value = true
                     if (installAfterApkDownload) {
                         downloadedApkFile.value = outFile
@@ -302,27 +355,37 @@ class MainViewModel : ViewModel() {
                         showApkUpdateDialog.value = true
                     }
                 }
+            } catch (e: CancellationException) {
+                tempFile?.delete()
+                throw e
             } catch (e: Exception) {
                 tempFile?.delete()
                 withContext(Dispatchers.Main) {
                     apkDownloading.value = false
                     apkProgress.value = null
+                    showApkMirrorPrompt.value = false
+                    apkUsingMirrorSource.value = false
                     apkErrorText.value = e.message ?: "下载失败"
                     if (showDialogWhenApkDownloadCompletes) {
                         showDialogWhenApkDownloadCompletes = false
                         showApkUpdateDialog.value = true
                     }
                 }
+            } finally {
+                mirrorPromptJob?.cancel()
             }
         }
     }
 
-    private suspend fun openApkDownloadResponse(initialUrl: String): Response<ResponseBody> {
+    private suspend fun openApkDownloadResponse(
+        initialUrl: String,
+        allowMirrorHost: Boolean
+    ): Response<ResponseBody> {
         var currentUrl = initialUrl
         repeat(ApkUpdatePolicy.MAX_DOWNLOAD_REDIRECTS + 1) { redirectCount ->
             val response = AhuTong.APK_DOWNLOAD_API.downloadByUrl(currentUrl)
             val finalUrl = response.raw().request.url.toString()
-            ApkUpdatePolicy.validateDownloadUrl(finalUrl).getOrElse {
+            ApkUpdatePolicy.validateDownloadUrl(finalUrl, allowMirrorHost = allowMirrorHost).getOrElse {
                 closeDownloadResponse(response)
                 throw SecurityException("下载地址不受信任")
             }
@@ -337,7 +400,11 @@ class MainViewModel : ViewModel() {
                 if (redirectCount >= ApkUpdatePolicy.MAX_DOWNLOAD_REDIRECTS) {
                     throw IOException("下载重定向次数过多")
                 }
-                currentUrl = ApkUpdatePolicy.validateDownloadUrl(location, finalUrl).getOrElse {
+                currentUrl = ApkUpdatePolicy.validateDownloadUrl(
+                    rawUrl = location,
+                    baseUrl = finalUrl,
+                    allowMirrorHost = allowMirrorHost
+                ).getOrElse {
                     throw SecurityException("下载重定向到不受信任地址")
                 }
                 return@repeat
@@ -346,6 +413,30 @@ class MainViewModel : ViewModel() {
             return response
         }
         throw IOException("下载重定向次数过多")
+    }
+
+    fun keepPrimaryApkDownload() {
+        showApkMirrorPrompt.value = false
+    }
+
+    fun switchApkDownloadToMirror(context: Context) {
+        val update = selectedValidatedUpdate() ?: return
+        showApkMirrorPrompt.value = false
+        if (!apkDownloading.value || apkUsingMirrorSource.value) return
+
+        val appContext = context.applicationContext
+        apkDownloadScope.launch {
+            apkDownloadJob?.cancelAndJoin()
+            withContext(Dispatchers.Main) {
+                if (apkLocalReady.value) {
+                    apkDownloading.value = false
+                    apkProgress.value = null
+                    apkUsingMirrorSource.value = false
+                } else {
+                    doApkDownload(appContext, update, useMirrorSource = true)
+                }
+            }
+        }
     }
 
     private fun closeDownloadResponse(response: Response<ResponseBody>) {

--- a/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
+++ b/app/src/test/java/com/ahu/ahutong/data/server/ApkUpdatePolicyTest.kt
@@ -89,6 +89,40 @@ class ApkUpdatePolicyTest {
     }
 
     @Test
+    fun validateRejectsMirrorDownloadHostByDefault() {
+        val result = ApkUpdatePolicy.validate(
+            updateInfo(url = "https://openahu-ahutong-cn.muxyang.com/download/app.apk"),
+            currentVersionCode = 1
+        )
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun validateAcceptsMirrorDownloadHostOnlyWhenExplicitlyAllowed() {
+        val result = ApkUpdatePolicy.validateDownloadUrl(
+            rawUrl = "https://openahu-ahutong-cn.muxyang.com/download/app.apk",
+            allowMirrorHost = true
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://openahu-ahutong-cn.muxyang.com/download/app.apk", result.getOrThrow())
+    }
+
+    @Test
+    fun mirrorDownloadUrlReplacesOnlyHost() {
+        val result = ApkUpdatePolicy.mirrorDownloadUrl(
+            "https://openahu.org/download/app.apk?channel=stable"
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            "https://openahu-ahutong-cn.muxyang.com/download/app.apk?channel=stable",
+            result.getOrThrow()
+        )
+    }
+
+    @Test
     fun validateResolvesRedirectLocationAgainstCurrentDownloadUrl() {
         val result = ApkUpdatePolicy.validateDownloadUrl(
             rawUrl = "next.apk",


### PR DESCRIPTION
**本次 PR 是一个较小的体验优化，主要面向部分访问官方下载源较慢的网络环境，用于在用户明确确认后提供镜像下载选择。由于该改动涉及 APK 分发链路，我完全理解维护者对安全边界和合并策略的审慎评估，也愿意根据 review 意见继续调整或撤回。**

本次更改仅调整 APK 更新流程中的下载文件逻辑，不修改更新信息获取、版本判断、SHA-256 获取与端侧校验逻辑。

变更后的逻辑如下：

1. 在客户端内置 `openahu-ahutong-cn.muxyang.com` 作为 APK 下载镜像源。
2. 当检测到官方下载源下载明显缓慢时，弹窗询问用户是否切换至镜像源。本次判断条件为：下载开始 5 秒后进度仍低于 30%。
3. 是否切换镜像源完全由用户确认；用户也可以继续使用官方源下载。
4. 在我的网络环境和服务器端已缓存完整 APK 文件的测试中（使用wget工具直接下载apk文件），官方源 `openahu.org` 下载速度约为 40KB/s，镜像源 `openahu-ahutong-cn.muxyang.com` 可达到 20MB/s+。

### 关于镜像源的安全性说明

1. 本次改动只影响 APK 文件下载地址。更新信息、目标版本、APK SHA-256 仍来自 `openahu.org` 的官方 API。
2. 镜像服务器从官方源获取官方更新信息，并使用官方返回的下载 URL 和 SHA-256 拉取、缓存 APK。服务端在发布缓存文件前会校验下载文件 SHA-256，发布后再次校验缓存文件 SHA-256。冷缓存或更新中的请求可能会流式转发正在下载的临时文件，但客户端仍会在下载完成后使用 `openahu.org` API 返回的 SHA-256 做最终校验；校验失败时不会进入安装流程。
3. 镜像源不会被接受为官方更新 metadata 中的默认下载 host；只有用户在下载较慢弹窗中确认后，客户端才会将官方 APK 下载路径映射到镜像源。
4. 镜像源域名 `muxyang.com` 为本人备案域名，当前用于分发的服务器也由本人维护。该镜像源主要用于改善部分网络环境下的 APK 下载速度。
5. 镜像源引入的剩余风险主要是可用性风险：如果镜像源不可用、文件缺失或文件校验失败，更新下载会失败或回退重试，但不会绕过官方 SHA-256 校验安装不一致 APK。

### 附件

服务器使用的代码：
[ahutong_cache.py](https://github.com/user-attachments/files/29420273/ahutong_cache.py)
速度测试：
<img width="1280" height="2856" alt="Screenshot_20260628-033006" src="https://github.com/user-attachments/assets/2c7fda7f-3bc3-4b3e-98f5-b17635fb0fda" />
基础镜像功能测试：
https://github.com/user-attachments/assets/c5a345c1-8025-4c0d-9e24-0eab76d73b85
