### PR TITLE
fix: 重构学习资料模块并修复导航、缓存与下载体验

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,9 +83,15 @@ android {
     }
 }
 
+val rustSdkArm64Output = project.file("src/main/jniLibs/arm64-v8a/libahutong_rs.so")
+val rebuildRustSdk = providers.environmentVariable("AHUTONG_REBUILD_RUST")
+    .map { it == "1" || it.equals("true", ignoreCase = true) }
+    .orElse(false)
+val shouldBuildRustSdkArm64 = rebuildRustSdk.get() || !rustSdkArm64Output.exists()
+
 val buildRustSdkArm64 by tasks.registering(Exec::class) {
     group = "build"
-    description = "Build the Rust SDK arm64-v8a shared library into app jniLibs."
+    description = "Build the Rust SDK arm64-v8a shared library into app jniLibs when requested."
 
     workingDir = rootProject.file("sdk")
     inputs.dir(rootProject.file("sdk/src"))
@@ -93,7 +99,7 @@ val buildRustSdkArm64 by tasks.registering(Exec::class) {
     inputs.file(rootProject.file("GuiXu-Rust/Cargo.toml"))
     inputs.file(rootProject.file("GuiXu-Rust/Cargo.lock"))
     inputs.file(rootProject.file("sdk/Cargo.toml"))
-    outputs.file(project.file("src/main/jniLibs/arm64-v8a/libahutong_rs.so"))
+    outputs.file(rustSdkArm64Output)
 
     commandLine(
         "cargo",
@@ -111,7 +117,9 @@ val buildRustSdkArm64 by tasks.registering(Exec::class) {
 
 tasks.matching { it.name == "mergeDebugJniLibFolders" || it.name == "mergeReleaseJniLibFolders" }
     .configureEach {
-        dependsOn(buildRustSdkArm64)
+        if (shouldBuildRustSdkArm64) {
+            dependsOn(buildRustSdkArm64)
+        }
     }
 
 dependencies {
@@ -140,6 +148,7 @@ dependencies {
     implementation(libs.monet)
     implementation(libs.kyant0.backdrop)
     implementation(libs.kyant0.capsule)
+    implementation(libs.markwon.core)
 
     implementation(platform(libs.kotlin.bom))
     implementation(libs.kotlin.stdlib)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/ahu/ahutong/data/dao/PreferencesManager.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/dao/PreferencesManager.kt
@@ -18,6 +18,7 @@ object PreferencesKeys {
     val COURSE_REMINDER_LIVE_COUNTDOWN_ENABLED =
         booleanPreferencesKey("course_reminder_live_countdown_enabled")
     val THEME_COLOR = stringPreferencesKey("theme_color_hex")
+    val REPOSITORY_ACCELERATION_SOURCE = stringPreferencesKey("repository_acceleration_source")
 }
 
 private val Context.dataStore by preferencesDataStore(name = "user_pref")
@@ -35,6 +36,16 @@ class PreferencesManager @Inject constructor(@ApplicationContext private val con
             } else {
                 prefs[PreferencesKeys.THEME_COLOR] = value
             }
+        }
+    }
+
+    val repositoryAccelerationSource: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[PreferencesKeys.REPOSITORY_ACCELERATION_SOURCE] ?: "jsdelivr"
+    }
+
+    suspend fun setRepositoryAccelerationSource(value: String) {
+        context.dataStore.edit { prefs ->
+            prefs[PreferencesKeys.REPOSITORY_ACCELERATION_SOURCE] = value
         }
     }
 

--- a/app/src/main/java/com/ahu/ahutong/data/repository/GitHubApi.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/repository/GitHubApi.kt
@@ -18,6 +18,14 @@ interface GitHubApi {
         @Query("ref") ref: String = "master"
     ): List<GitHubContentItem>
 
+    @GET("repos/{owner}/{repo}/git/trees/{tree}")
+    suspend fun getTree(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+        @Path("tree") tree: String,
+        @Query("recursive") recursive: String = "1"
+    ): GitHubTreeResponse
+
     companion object {
         private const val BASE_URL = "https://api.github.com/"
 

--- a/app/src/main/java/com/ahu/ahutong/data/repository/GitHubModels.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/repository/GitHubModels.kt
@@ -13,7 +13,30 @@ data class GitHubContentItem(
     @SerializedName("download_url")
     val downloadUrl: String? = null,
     @SerializedName("html_url")
-    val htmlUrl: String? = null
+    val htmlUrl: String? = null,
+    val repositoryId: String? = null,
+    val repositoryPath: String? = null,
+    val containsOnlyUnsupportedFiles: Boolean = false
+)
+
+data class GitHubTreeResponse(
+    val tree: List<GitHubTreeItem> = emptyList(),
+    val truncated: Boolean = false
+)
+
+data class GitHubTreeItem(
+    val path: String,
+    val type: String,        // "blob" or "tree"
+    val size: Long = 0
+)
+
+data class JsDelivrFlatResponse(
+    val files: List<JsDelivrFlatFile> = emptyList()
+)
+
+data class JsDelivrFlatFile(
+    val name: String,
+    val size: Long = 0
 )
 
 /**
@@ -24,7 +47,8 @@ data class DownloadedFile(
     val path: String,         // GitHub 路径
     val localPath: String,    // 本地文件路径
     val size: Long = 0,
-    val downloadTime: Long = System.currentTimeMillis()
+    val downloadTime: Long = System.currentTimeMillis(),
+    val uri: String? = null
 )
 
 /**
@@ -48,4 +72,23 @@ data class RepoConfig(
 data class CachedRepositoryContents(
     val items: List<GitHubContentItem>,
     val updateTime: Long
+)
+
+data class RepositoryDirectorySummary(
+    val directoryCount: Int = 0,
+    val fileCount: Int = 0
+)
+
+data class RepositoryMarkdownDocument(
+    val title: String,
+    val path: String,
+    val content: String
+)
+
+data class RepositoryAccelerationSource(
+    val id: String,
+    val name: String,
+    val description: String,
+    val proxyPrefix: String? = null,
+    val useJsDelivr: Boolean = false
 )

--- a/app/src/main/java/com/ahu/ahutong/data/repository/RepositoryManager.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/repository/RepositoryManager.kt
@@ -43,7 +43,7 @@ object RepositoryManager {
     private const val CONTENT_TREE_CACHE_TIME_KEY = "content_tree_cache_time"
     private const val CONTENT_TREE_CACHE_VERSION_KEY = "content_tree_cache_version"
     private const val CONTENT_UNSUPPORTED_PATHS_KEY = "content_unsupported_paths"
-    private const val CONTENT_CACHE_VERSION = 6
+    private const val CONTENT_CACHE_VERSION = 7
     private const val DOWNLOAD_RECORDS_KEY = "downloaded_files"
     private const val DOWNLOAD_RELATIVE_ROOT = "ahutong"
     private const val GIT_LFS_POINTER_PREFIX = "version https://git-lfs.github.com/spec/v1"
@@ -82,9 +82,9 @@ object RepositoryManager {
         RepositorySource(
             id = "internet",
             title = "互联网学院",
-            owner = "LaPhilosophie",
-            repo = "AHU-CyberSecurity",
-            branch = "master"
+            owner = "Zeraora-807",
+            repo = "AHU-Internet-Exams-Archive",
+            branch = "main"
         ),
         RepositorySource(
             id = "sbi",
@@ -172,7 +172,9 @@ object RepositoryManager {
             warmUpMutex.withLock {
                 val cachedUpdateTime = kv.decodeLong(CONTENT_TREE_CACHE_TIME_KEY, 0L)
                 val cachedVersion = kv.decodeInt(CONTENT_TREE_CACHE_VERSION_KEY, 0)
+                // UI warm-up passes onProgress and should refresh remote trees even when cache exists.
                 if (!forceRefresh &&
+                    onProgress == null &&
                     cachedUpdateTime > 0L &&
                     cachedVersion == CONTENT_CACHE_VERSION &&
                     getCachedContents("") != null
@@ -941,8 +943,8 @@ object RepositoryManager {
     }
 
     private fun matchesCurrentRepositorySources(items: List<GitHubContentItem>): Boolean {
-        val cachedRoots = items.map { it.path to it.name }
-        val expectedRoots = repositoryRootItems().map { it.path to it.name }
+        val cachedRoots = items.map { listOf(it.path, it.name, it.htmlUrl.orEmpty()) }
+        val expectedRoots = repositoryRootItems().map { listOf(it.path, it.name, it.htmlUrl.orEmpty()) }
         return cachedRoots == expectedRoots
     }
 

--- a/app/src/main/java/com/ahu/ahutong/data/repository/RepositoryManager.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/repository/RepositoryManager.kt
@@ -1,41 +1,134 @@
 package com.ahu.ahutong.data.repository
 
+import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.provider.OpenableColumns
 import android.util.Base64
 import com.ahu.ahutong.AHUApplication
+import com.ahu.ahutong.data.dao.PreferencesManager
 import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonParser
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import java.io.File
-import java.io.FileOutputStream
-import java.util.concurrent.TimeUnit
+import okhttp3.Response
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
 
 object RepositoryManager {
+    private const val RAW_HOST = "https://raw.githubusercontent.com"
+    private const val GITHUB_HOST = "https://github.com"
+    private const val CDN_HOST = "https://cdn.jsdelivr.net/gh"
+    private const val CONTENT_CACHE_PREFIX = "content_cache_"
+    private const val CONTENT_CACHE_TIME_PREFIX = "content_cache_time_"
+    private const val CONTENT_TREE_CACHE_TIME_KEY = "content_tree_cache_time"
+    private const val CONTENT_TREE_CACHE_VERSION_KEY = "content_tree_cache_version"
+    private const val CONTENT_UNSUPPORTED_PATHS_KEY = "content_unsupported_paths"
+    private const val CONTENT_CACHE_VERSION = 6
+    private const val DOWNLOAD_RECORDS_KEY = "downloaded_files"
+    private const val DOWNLOAD_RELATIVE_ROOT = "ahutong"
+    private const val GIT_LFS_POINTER_PREFIX = "version https://git-lfs.github.com/spec/v1"
+    private const val GIT_LFS_POINTER_MAX_BYTES = 1024
+    private val GIT_LFS_BATCH_MEDIA_TYPE = "application/vnd.git-lfs+json".toMediaType()
 
-    val repositories = listOf(
-        RepoConfig("cs", "计算机科学与技术学院", "Kaltsit-cell", "AHU-CS-Repository", branch = "master"),
-        RepoConfig("ai", "人工智能学院", "DylanAo", "AHU-AI-Repository", branch = "main"),
-        RepoConfig("ic", "集成电路学院", "Tonyseth", "AHU-IC-Design-personal-Repository", branch = "main"),
-        RepoConfig("ee", "电子信息工程学院", "HarryWeasley3", "AHU-EE-Repository", branch = "main"),
-        RepoConfig("internet", "互联网学院", "Zeraora-807", "AHU-Internet-Exams-Archive", branch = "main"),
-        RepoConfig("sbi", "石溪学院", "UponNoise", "AHU_SBI_DMT", branch = "main")
+    private val repositorySources = listOf(
+        RepositorySource(
+            id = "cs",
+            title = "计算机科学与技术学院",
+            owner = "Kaltsit-cell",
+            repo = "AHU-CS-Repository",
+            branch = "master"
+        ),
+        RepositorySource(
+            id = "ai",
+            title = "人工智能学院",
+            owner = "DylanAo",
+            repo = "AHU-AI-Repository",
+            branch = "main"
+        ),
+        RepositorySource(
+            id = "ic",
+            title = "集成电路学院",
+            owner = "Tonyseth",
+            repo = "AHU-IC-Design-personal-Repository",
+            branch = "main"
+        ),
+        RepositorySource(
+            id = "ee",
+            title = "电子信息工程学院",
+            owner = "HarryWeasley3",
+            repo = "AHU-EE-Repository",
+            branch = "main"
+        ),
+        RepositorySource(
+            id = "internet",
+            title = "互联网学院",
+            owner = "LaPhilosophie",
+            repo = "AHU-CyberSecurity",
+            branch = "master"
+        ),
+        RepositorySource(
+            id = "sbi",
+            title = "石溪学院",
+            owner = "UponNoise",
+            repo = "AHU_SBI_DMT",
+            branch = "main"
+        )
     )
+    private val repositorySourceById = repositorySources.associateBy { it.id }
+    private val repositoryTitleById = repositorySources.associate { it.id to it.title }
 
-    private val repoById = repositories.associateBy { it.id }
-
-    fun getRepo(repoId: String): RepoConfig = repoById[repoId] ?: repositories.first()
-    fun getRepoUrl(repoId: String): String = getRepo(repoId).githubUrl
+    val accelerationSources = listOf(
+        RepositoryAccelerationSource(
+            id = "jsdelivr",
+            name = "jsDelivr",
+            description = "默认优先使用 jsDelivr CDN",
+            useJsDelivr = true
+        ),
+        RepositoryAccelerationSource(
+            id = "moeyy",
+            name = "Moeyy",
+            description = "通过 github.moeyy.xyz 加速 GitHub 原始文件",
+            proxyPrefix = "https://github.moeyy.xyz/"
+        ),
+        RepositoryAccelerationSource(
+            id = "gh-proxy",
+            name = "gh-proxy",
+            description = "通过 gh-proxy.com 加速 GitHub 原始文件",
+            proxyPrefix = "https://gh-proxy.com/"
+        ),
+        RepositoryAccelerationSource(
+            id = "direct",
+            name = "GitHub 直连",
+            description = "不使用加速源，直接连接 GitHub"
+        )
+    )
 
     private val gson = Gson()
     private val kv: MMKV by lazy {
         MMKV.initialize(AHUApplication.getApp())
         MMKV.mmkvWithID("repository_downloads")
     }
+    private val warmUpMutex = Mutex()
 
     private val downloadClient = OkHttpClient.Builder()
         .connectTimeout(10, TimeUnit.SECONDS)
@@ -44,192 +137,1085 @@ object RepositoryManager {
         .followRedirects(true)
         .build()
 
-    // === Prefix helpers (scoped per repo) ===
-
-    private fun contentCachePrefix(repoId: String) = "content_cache_$repoId/"
-    private fun contentCacheTimePrefix(repoId: String) = "content_cache_time_$repoId/"
-    private fun contentCacheKey(repoId: String, path: String) = Base64.encodeToString(
-        path.toByteArray(Charsets.UTF_8), Base64.NO_WRAP or Base64.URL_SAFE
-    )
-
     // === GitHub API ===
 
-    suspend fun getContents(repoId: String, path: String = ""): List<GitHubContentItem> {
-        val repo = getRepo(repoId)
+    suspend fun getContents(path: String = "", forceRefresh: Boolean = false): List<GitHubContentItem> {
         return withContext(Dispatchers.IO) {
-            GitHubApi.instance.getContents(repo.owner, repo.repo, encodePath(path), repo.branch).also {
-                saveContentCache(repoId, path, it)
+            val fallbackRootItems = if (path.isBlank()) repositoryRootItems() else null
+
+            if (!forceRefresh) {
+                getCachedContents(path)?.items?.let { return@withContext it }
+            }
+
+            runCatching {
+                warmUpAllContentCaches(
+                    forceRefresh = forceRefresh || getCachedContents(path) == null
+                )
+            }.onSuccess {
+                getCachedContents(path)?.items?.let { return@withContext it }
+            }.onFailure {
+                fallbackRootItems?.let { return@withContext it }
+            }
+
+            getCachedContents(path)?.items?.let { return@withContext it }
+            fallbackRootItems?.let { return@withContext it }
+
+            throw IllegalStateException("目录缓存不可用")
+        }
+    }
+
+    suspend fun warmUpAllContentCaches(
+        forceRefresh: Boolean = false,
+        onProgress: ((Int) -> Unit)? = null
+    ): Long {
+        return withContext(Dispatchers.IO) {
+            warmUpMutex.withLock {
+                val cachedUpdateTime = kv.decodeLong(CONTENT_TREE_CACHE_TIME_KEY, 0L)
+                val cachedVersion = kv.decodeInt(CONTENT_TREE_CACHE_VERSION_KEY, 0)
+                if (!forceRefresh &&
+                    cachedUpdateTime > 0L &&
+                    cachedVersion == CONTENT_CACHE_VERSION &&
+                    getCachedContents("") != null
+                ) {
+                    return@withLock cachedUpdateTime
+                }
+
+                val grouped = buildAllDirectoryCaches(onProgress)
+                val updateTime = System.currentTimeMillis()
+                grouped.forEach { (path, items) ->
+                    saveContentCache(path, items, updateTime)
+                }
+                kv.encode(CONTENT_TREE_CACHE_TIME_KEY, updateTime)
+                kv.encode(CONTENT_TREE_CACHE_VERSION_KEY, CONTENT_CACHE_VERSION)
+                updateTime
             }
         }
     }
 
-    fun getCachedContents(repoId: String, path: String = ""): CachedRepositoryContents? {
-        val key = contentCacheKey(repoId, path)
-        val json = kv.decodeString("${contentCachePrefix(repoId)}$key", null) ?: return null
-        return try {
+    fun getCachedContents(path: String = ""): CachedRepositoryContents? {
+        if (kv.decodeInt(CONTENT_TREE_CACHE_VERSION_KEY, 0) != CONTENT_CACHE_VERSION) {
+            return null
+        }
+        val key = contentCacheKey(path)
+        val json = kv.decodeString("$CONTENT_CACHE_PREFIX$key", null) ?: return null
+        val cached = try {
             val type = object : TypeToken<List<GitHubContentItem>>() {}.type
             val items: List<GitHubContentItem> = gson.fromJson(json, type)
             CachedRepositoryContents(
                 items = items,
-                updateTime = kv.decodeLong("${contentCacheTimePrefix(repoId)}$key", 0L)
+                updateTime = kv.decodeLong("$CONTENT_CACHE_TIME_PREFIX$key", 0L)
             )
         } catch (e: Exception) {
             null
+        } ?: return null
+
+        if (normalizeRepositoryPath(path).isEmpty() && !matchesCurrentRepositorySources(cached.items)) {
+            return null
+        }
+
+        if (cached.items.any { it.name.contains('/') || it.name.contains('\\') }) {
+            return null
+        }
+
+        return cached
+    }
+
+    fun shouldShowUnsupportedDirectoryMessage(path: String): Boolean {
+        if (path.isBlank()) return false
+        return getUnsupportedDirectoryPaths().contains(normalizeRepositoryPath(path))
+    }
+
+    fun getDirectorySummaries(items: List<GitHubContentItem>): Map<String, RepositoryDirectorySummary> {
+        return items
+            .filter { it.type == "dir" }
+            .associate { item ->
+                val cachedChildren = getCachedContents(item.path)?.items.orEmpty()
+                item.path to RepositoryDirectorySummary(
+                    directoryCount = cachedChildren.count { it.type == "dir" },
+                    fileCount = cachedChildren.count { it.type == "file" }
+                )
+            }
+    }
+
+    fun getRawUrl(path: String): String {
+        val resolved = resolveVirtualPath(path) ?: return ""
+        return resolved.source.rawUrl(resolved.repositoryPath)
+    }
+
+    fun getGitHubUrl(path: String): String {
+        val resolved = resolveVirtualPath(path) ?: return repositoryRootUrl()
+        return resolved.source.githubUrl(resolved.repositoryPath, tree = true)
+    }
+
+    fun getRepositoryTitle(repoId: String): String {
+        return repositoryTitleById[repoId] ?: repoId
+    }
+
+    fun getRepositoryOrder(path: String): Int {
+        val repositoryId = normalizeRepositoryPath(path).substringBefore('/', "")
+        val index = repositorySources.indexOfFirst { it.id == repositoryId }
+        return if (index >= 0) index else Int.MAX_VALUE
+    }
+
+    fun formatDisplayPath(path: String): String {
+        val normalized = normalizeRepositoryPath(path)
+        if (normalized.isBlank()) return "学习资料"
+        val segments = normalized.split('/').filter { it.isNotBlank() }
+        if (segments.isEmpty()) return "学习资料"
+        val repositoryId = segments.first()
+        val repositoryTitle = getRepositoryTitle(repositoryId)
+        val displaySegments = buildList {
+            add(repositoryTitle)
+            val relativeSegments = segments.drop(1)
+            val trimmedRelativeSegments = if (relativeSegments.firstOrNull() == repositoryTitle) {
+                relativeSegments.drop(1)
+            } else {
+                relativeSegments
+            }
+            addAll(trimmedRelativeSegments)
+        }
+        return displaySegments.joinToString("/")
+    }
+
+    suspend fun getMarkdownDocument(path: String): RepositoryMarkdownDocument {
+        return withContext(Dispatchers.IO) {
+            val resolved = resolveVirtualPath(path)
+                ?: throw IllegalArgumentException("无效的 Markdown 路径")
+            val urls = getDownloadUrls(path, AHUApplication.getApp())
+            val selectedAccelerationSource = getSelectedAccelerationSource(AHUApplication.getApp())
+            var lastError: Exception? = null
+            for (url in urls) {
+                try {
+                    val request = Request.Builder().url(url).build()
+                    downloadClient.newCall(request).execute().use { response ->
+                        if (!response.isSuccessful) {
+                            lastError = IllegalStateException("HTTP ${response.code}")
+                            return@use
+                        }
+                        val content = response.readGitLfsMarkdown(
+                            source = resolved.source,
+                            accelerationSource = selectedAccelerationSource
+                        )
+                            ?: response.body?.string().orEmpty()
+                        return@withContext RepositoryMarkdownDocument(
+                            title = File(resolved.repositoryPath).name.ifBlank { "Markdown" },
+                            path = path,
+                            content = content
+                        )
+                    }
+                } catch (e: Exception) {
+                    lastError = e
+                }
+            }
+            throw lastError ?: IllegalStateException("无法读取 Markdown")
         }
     }
 
-    fun getRawUrl(repoId: String, path: String): String {
-        val repo = getRepo(repoId)
-        return "${repo.rawBase}/${encodePath(path)}"
-    }
-
-    private fun getDownloadUrls(repoId: String, path: String): List<String> {
-        val repo = getRepo(repoId)
-        return listOf(
-            "${repo.cdnBase}/${encodePath(path)}",
-            "${repo.rawBase}/${encodePath(path)}"
-        )
+    private suspend fun getDownloadUrls(path: String, context: Context): List<String> {
+        val resolved = resolveVirtualPath(path) ?: return emptyList()
+        val selectedSource = getSelectedAccelerationSource(context)
+        val rawUrl = resolved.source.rawUrl(resolved.repositoryPath)
+        val cdnUrl = resolved.source.cdnUrl(resolved.repositoryPath)
+        val selectedUrl = when {
+            selectedSource.useJsDelivr -> cdnUrl
+            selectedSource.proxyPrefix != null -> selectedSource.proxyPrefix + rawUrl
+            else -> rawUrl
+        }
+        return listOf(selectedUrl, cdnUrl, rawUrl).distinct()
     }
 
     // === 下载管理 ===
 
-    private fun getDownloadDir(context: Context): File {
+    fun getDownloadedFiles(context: Context): List<DownloadedFile> {
+        val records = getDownloadRecords()
+        val files = records.mapNotNull { record ->
+            record.toDownloadedFile(context) ?: run {
+                removeDownloadRecord(record.path)
+                null
+            }
+        }
+        return files.sortedByDescending { it.downloadTime }
+    }
+
+    fun getDownloadedFile(path: String, context: Context): DownloadedFile? {
+        val record = getDownloadRecords().firstOrNull { it.path == path } ?: return null
+        return record.toDownloadedFile(context) ?: run {
+            removeDownloadRecord(path)
+            null
+        }
+    }
+
+    fun isDownloaded(path: String, context: Context): Boolean {
+        return getDownloadedFile(path, context) != null
+    }
+
+    suspend fun downloadFile(
+        path: String,
+        context: Context,
+        onProgress: (Float) -> Unit = {}
+    ): DownloadedFile? = withContext(Dispatchers.IO) {
+        val appContext = context.applicationContext
+        val resolved = resolveVirtualPath(path) ?: return@withContext null
+        val urls = getDownloadUrls(path, appContext)
+        val selectedAccelerationSource = getSelectedAccelerationSource(appContext)
+        val previousRecord = getDownloadRecord(path)
+        val target = createDownloadTarget(path, appContext)
+
+        for ((index, url) in urls.withIndex()) {
+            try {
+                val request = Request.Builder().url(url).build()
+                var gitLfsPointer: GitLfsPointer? = null
+                var gitLfsDownload: GitLfsDownloadAction? = null
+                downloadClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        return@use
+                    }
+                    val pointer = response.readGitLfsPointer()
+                    if (pointer != null) {
+                        gitLfsPointer = pointer
+                        gitLfsDownload = resolveGitLfsDownload(resolved.source, pointer)
+                        return@use
+                    }
+
+                    val body = response.body ?: return@use
+                    val total = body.contentLength()
+                    var downloadedBytes = 0L
+
+                    body.byteStream().use { input ->
+                        target.openOutputStream().use { output ->
+                            val buffer = ByteArray(8 * 1024)
+                            var completed: Long = 0
+                            var read = input.read(buffer)
+                            while (read >= 0) {
+                                output.write(buffer, 0, read)
+                                completed += read
+                                downloadedBytes = completed
+                                if (total > 0) {
+                                    onProgress(completed.toFloat() / total.toFloat())
+                                }
+                                read = input.read(buffer)
+                            }
+                            output.flush()
+                        }
+                    }
+
+                    target.markCompleted()
+                    if (target is DownloadTarget.MediaStoreTarget || previousRecord?.uri != null) {
+                        previousRecord?.delete(appContext)
+                    }
+                    removeDownloadRecord(path)
+                    val record = DownloadRecord(
+                        path = path,
+                        localName = target.relativePath,
+                        uri = target.uri?.toString(),
+                        localPath = target.displayPath,
+                        downloadTime = System.currentTimeMillis(),
+                        size = downloadedBytes
+                    )
+                    saveDownloadRecord(record)
+                    return@withContext record.toDownloadedFile(appContext)
+                }
+
+                if (gitLfsPointer != null) {
+                    val lfsDownload = gitLfsDownload
+                    if (lfsDownload != null) {
+                        val lfsResult = downloadGitLfsFile(
+                            urls = buildLfsDownloadUrls(
+                                href = lfsDownload.href,
+                                accelerationSource = selectedAccelerationSource
+                            ),
+                            headers = lfsDownload.header,
+                            path = path,
+                            context = appContext,
+                            target = target,
+                            previousRecord = previousRecord,
+                            pointer = gitLfsPointer,
+                            onProgress = onProgress
+                        )
+                        if (lfsResult != null) return@withContext lfsResult
+                    }
+                }
+            } catch (e: Exception) {
+                if (index == urls.lastIndex) {
+                    target.delete()
+                    return@withContext null
+                }
+            }
+        }
+        target.delete()
+        null
+    }
+
+    fun getLocalFile(path: String, context: Context): File? {
+        val file = getDownloadedFile(path, context) ?: return null
+        val localFile = File(file.localPath)
+        return if (localFile.exists()) localFile else null
+    }
+
+    fun deleteFile(path: String, context: Context): Boolean {
+        val record = getDownloadRecords().firstOrNull { it.path == path } ?: return false
+        val deleted = record.delete(context)
+        if (deleted) {
+            removeDownloadRecord(path)
+        }
+        return deleted
+    }
+
+    // === 内部方法 ===
+
+    private suspend fun buildAllDirectoryCaches(
+        onProgress: ((Int) -> Unit)? = null
+    ): Map<String, List<GitHubContentItem>> {
+        val progressCounter = AtomicInteger(0)
+        val repositoryCaches = supervisorScope {
+            repositorySources.map { source ->
+                async {
+                    val result = runCatching {
+                        val tree = runCatching {
+                            GitHubApi.instance.getTree(
+                                owner = source.owner,
+                                repo = source.repo,
+                                tree = source.branch
+                            ).tree
+                        }.recoverCatching {
+                            val treeSha = resolveRepositoryTreeSha(source)
+                            GitHubApi.instance.getTree(
+                                owner = source.owner,
+                                repo = source.repo,
+                                tree = treeSha
+                            ).tree
+                        }.getOrThrow()
+                        source to buildDirectoryCachesFromGitHubTree(source, tree)
+                    }
+                    if (result.isSuccess) {
+                        val fileCount = result.getOrNull()?.second?.documentFileCount ?: 0
+                        onProgress?.invoke(progressCounter.addAndGet(fileCount))
+                    }
+                    result
+                }
+            }.awaitAll()
+        }
+
+        val grouped = mutableMapOf("" to repositoryRootItems())
+        val unsupportedPaths = mutableSetOf<String>()
+        repositoryCaches.mapNotNull { it.getOrNull() }.forEach { (_, cache) ->
+            grouped.putAll(cache.grouped)
+            unsupportedPaths += cache.unsupportedDirectoryPaths
+        }
+        if (grouped.size == 1 && repositoryCaches.all { it.isFailure }) {
+            throw repositoryCaches.firstNotNullOfOrNull { it.exceptionOrNull() }
+                ?: IllegalStateException("无法构建目录索引")
+        }
+        saveUnsupportedDirectoryPaths(unsupportedPaths)
+        return grouped
+    }
+
+    private fun repositoryRootItems(): List<GitHubContentItem> {
+        return repositorySources.map { source ->
+            GitHubContentItem(
+                name = source.title,
+                path = source.id,
+                type = "dir",
+                htmlUrl = source.githubUrl("", tree = true),
+                repositoryId = source.id,
+                repositoryPath = ""
+            )
+        }
+    }
+
+    private fun buildDirectoryCachesFromGitHubTree(
+        source: RepositorySource,
+        tree: List<GitHubTreeItem>
+    ): RepositoryIndexCache {
+        val resolvedLfsSizes = resolveGitLfsDisplaySizes(source, tree)
+        val allChildren = mutableMapOf<String, MutableList<GitHubTreeItem>>()
+        val allDirectories = mutableSetOf("")
+
+        tree.forEach { treeItem ->
+            val repositoryPath = normalizeRepositoryPath(treeItem.path)
+            if (repositoryPath.isEmpty()) return@forEach
+
+            val parent = repositoryPath.substringBeforeLast('/', "")
+            allChildren.getOrPut(parent) { mutableListOf() }.add(
+                treeItem.copy(path = repositoryPath)
+            )
+            allDirectories += parent
+            if (treeItem.type == "tree") {
+                allDirectories += repositoryPath
+            }
+        }
+
+        val displayChildren = mutableMapOf<String, MutableList<GitHubContentItem>>()
+        val displayableDirectories = mutableSetOf<String>()
+        val unsupportedDirectoryPaths = mutableSetOf<String>()
+
+        val directoriesByDepth = allDirectories.sortedByDescending { path ->
+            if (path.isEmpty()) 0 else path.count { it == '/' } + 1
+        }
+        directoriesByDepth.forEach { repositoryPath ->
+            val children = allChildren[repositoryPath].orEmpty()
+            val displayed = children.mapNotNull { child ->
+                val childPath = normalizeRepositoryPath(child.path)
+                val childName = childPath.substringAfterLast('/')
+                when {
+                    child.type == "blob" && isDocumentFile(childName) -> {
+                        GitHubContentItem(
+                            name = childName,
+                            path = virtualPath(source, childPath),
+                            type = "file",
+                            size = resolvedLfsSizes[childPath] ?: child.size,
+                            downloadUrl = source.rawUrl(childPath),
+                            htmlUrl = source.githubUrl(childPath, tree = false),
+                            repositoryId = source.id,
+                            repositoryPath = childPath
+                        )
+                    }
+                    child.type == "tree" && childPath in displayableDirectories -> {
+                        GitHubContentItem(
+                            name = childName,
+                            path = virtualPath(source, childPath),
+                            type = "dir",
+                            htmlUrl = source.githubUrl(childPath, tree = true),
+                            repositoryId = source.id,
+                            repositoryPath = childPath
+                        )
+                    }
+                    else -> null
+                }
+            }
+
+            val virtualDirectoryPath = virtualPath(source, repositoryPath)
+            displayChildren[virtualDirectoryPath] = displayed.toMutableList()
+            if (displayed.isNotEmpty()) {
+                displayableDirectories += repositoryPath
+            } else if (children.isNotEmpty()) {
+                unsupportedDirectoryPaths += virtualDirectoryPath
+            }
+        }
+
+        displayChildren.forEach { (virtualDirectoryPath, children) ->
+            val resolved = resolveVirtualPath(virtualDirectoryPath) ?: return@forEach
+            children.addAll(
+                allChildren[resolved.repositoryPath].orEmpty().mapNotNull { child ->
+                    val childPath = normalizeRepositoryPath(child.path)
+                    if (child.type != "tree" || childPath in displayableDirectories) {
+                        return@mapNotNull null
+                    }
+                    val childVirtualPath = virtualPath(source, childPath)
+                    if (childVirtualPath !in unsupportedDirectoryPaths) return@mapNotNull null
+                    GitHubContentItem(
+                        name = childPath.substringAfterLast('/'),
+                        path = childVirtualPath,
+                        type = "dir",
+                        htmlUrl = source.githubUrl(childPath, tree = true),
+                        repositoryId = source.id,
+                        repositoryPath = childPath,
+                        containsOnlyUnsupportedFiles = true
+                    )
+                }
+            )
+        }
+
+        return RepositoryIndexCache(
+            grouped = displayChildren.mapValues { (_, items) ->
+                sortRepositoryItems(items.distinctBy { it.path })
+            },
+            unsupportedDirectoryPaths = unsupportedDirectoryPaths,
+            documentFileCount = tree.count { treeItem ->
+                treeItem.type == "blob" && isDocumentFile(treeItem.path.substringAfterLast('/'))
+            }
+        )
+    }
+
+    private fun getDownloadRecords(): List<DownloadRecord> {
+        val json = kv.decodeString(DOWNLOAD_RECORDS_KEY, "[]") ?: "[]"
+        return try {
+            val element = JsonParser.parseString(json)
+            if (!element.isJsonArray) return emptyList()
+            val array = element.asJsonArray
+            if (array.size() == 0) {
+                emptyList()
+            } else if (array.firstOrNull()?.isJsonArray == true) {
+                parseLegacyDownloadRecords(array)
+            } else {
+                val type = object : TypeToken<List<DownloadRecord>>() {}.type
+                gson.fromJson<List<DownloadRecord>>(array, type).filter { it.path.isNotEmpty() }
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun getDownloadRecord(path: String): DownloadRecord? {
+        return getDownloadRecords().firstOrNull { it.path == path }
+    }
+
+    private fun parseLegacyDownloadRecords(array: JsonArray): List<DownloadRecord> {
+        return array.mapNotNull { element ->
+            val item = element.takeIf { it.isJsonArray }?.asJsonArray ?: return@mapNotNull null
+            if (item.size() < 2) return@mapNotNull null
+            val path = item[0].asString
+            val localName = item[1].asString
+            DownloadRecord(
+                path = path,
+                localName = localName,
+                localPath = File(getLegacyDownloadDir(AHUApplication.getApp()), localName).absolutePath
+            )
+        }
+    }
+
+    private fun saveDownloadRecord(record: DownloadRecord) {
+        val files = getDownloadRecords().toMutableList()
+        files.removeAll { it.path == record.path }
+        files.add(record)
+        kv.encode(DOWNLOAD_RECORDS_KEY, gson.toJson(files))
+    }
+
+    private fun removeDownloadRecord(path: String) {
+        val files = getDownloadRecords().toMutableList()
+        files.removeAll { it.path == path }
+        kv.encode(DOWNLOAD_RECORDS_KEY, gson.toJson(files))
+    }
+
+    private fun saveContentCache(
+        path: String,
+        items: List<GitHubContentItem>,
+        updateTime: Long = System.currentTimeMillis()
+    ) {
+        val key = contentCacheKey(path)
+        kv.encode("$CONTENT_CACHE_PREFIX$key", gson.toJson(items))
+        kv.encode("$CONTENT_CACHE_TIME_PREFIX$key", updateTime)
+    }
+
+    private fun createDownloadTarget(path: String, context: Context): DownloadTarget {
+        val relativePath = safeRelativeFilePath(path)
+        val parent = relativePath.substringBeforeLast('/', "")
+        val displayName = relativePath.substringAfterLast('/').ifEmpty { "repository_file" }
+        val relativeDirectory = listOf(
+            Environment.DIRECTORY_DOWNLOADS,
+            DOWNLOAD_RELATIVE_ROOT,
+            parent
+        )
+            .filter { it.isNotEmpty() }
+            .joinToString("/")
+            .let { "$it/" }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val resolver = context.contentResolver
+            val values = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+                put(MediaStore.MediaColumns.MIME_TYPE, "application/octet-stream")
+                put(MediaStore.MediaColumns.RELATIVE_PATH, relativeDirectory)
+                put(MediaStore.MediaColumns.IS_PENDING, 1)
+            }
+            val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                ?: throw IllegalStateException("无法创建下载文件")
+            val displayPath = File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                "$DOWNLOAD_RELATIVE_ROOT/$relativePath"
+            ).absolutePath
+            DownloadTarget.MediaStoreTarget(context, uri, relativePath, displayPath)
+        } else {
+            val file = File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                "$DOWNLOAD_RELATIVE_ROOT/$relativePath"
+            )
+            file.parentFile?.mkdirs()
+            DownloadTarget.FileTarget(file, relativePath)
+        }
+    }
+
+    private fun getLegacyDownloadDir(context: Context): File {
         val root = context.getExternalFilesDir(null) ?: context.filesDir
         val dir = File(root, "repository")
         if (!dir.exists()) dir.mkdirs()
         return dir
     }
 
-    fun getDownloadedFiles(context: Context): List<DownloadedFile> {
-        val files = getDownloadedPaths(context)
-        return files.mapNotNull { (path, localName) ->
-            val file = File(getDownloadDir(context), localName)
-            if (file.exists()) {
-                DownloadedFile(
-                    name = File(path).name,
-                    path = path,
-                    localPath = file.absolutePath,
-                    size = file.length(),
-                    downloadTime = file.lastModified()
-                )
-            } else {
-                removeDownloadRecord(path)
-                null
+    private fun safeRelativeFilePath(path: String): String {
+        val segments = path
+            .replace('\\', '/')
+            .split('/')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && it != "." && it != ".." }
+        return segments.joinToString("/").ifEmpty { "repository_file" }
+    }
+
+    private fun sortRepositoryItems(items: List<GitHubContentItem>): List<GitHubContentItem> {
+        val dirs = items.filter { it.type == "dir" }.sortedBy { it.name.lowercase() }
+        val files = items.filter { it.type == "file" }.sortedBy { it.name.lowercase() }
+        return dirs + files
+    }
+
+    private suspend fun getSelectedAccelerationSource(context: Context): RepositoryAccelerationSource {
+        val selectedId = PreferencesManager(context.applicationContext)
+            .repositoryAccelerationSource
+            .first()
+        return accelerationSources.firstOrNull { it.id == selectedId } ?: accelerationSources.first()
+    }
+
+    private fun resolveGitLfsDisplaySizes(
+        source: RepositorySource,
+        tree: List<GitHubTreeItem>
+    ): Map<String, Long> {
+        val candidatePaths = tree.asSequence()
+            .filter { it.type == "blob" }
+            .filter { it.size in 1..GIT_LFS_POINTER_MAX_BYTES.toLong() }
+            .map { normalizeRepositoryPath(it.path) }
+            .filter { it.isNotEmpty() && isDocumentFile(it.substringAfterLast('/')) }
+            .toList()
+
+        if (candidatePaths.isEmpty()) return emptyMap()
+
+        return candidatePaths.mapNotNull { repositoryPath ->
+            val request = Request.Builder()
+                .url(source.rawUrl(repositoryPath))
+                .header("User-Agent", "AHUTong-Android")
+                .build()
+            val size = runCatching {
+                downloadClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    response.readGitLfsPointer()?.size
+                }
+            }.getOrNull()
+            size?.let { repositoryPath to it }
+        }.toMap()
+    }
+
+    private fun isDocumentFile(name: String): Boolean {
+        val lower = name.lowercase()
+        return lower.endsWith(".pdf") || lower.endsWith(".doc") ||
+            lower.endsWith(".docx") || lower.endsWith(".ppt") ||
+            lower.endsWith(".pptx") || lower.endsWith(".xls") ||
+            lower.endsWith(".xlsx") || lower.endsWith(".txt") ||
+            lower.endsWith(".md")
+    }
+
+    private fun Response.readGitLfsPointer(): GitLfsPointer? {
+        val preview = runCatching {
+            peekBody(GIT_LFS_POINTER_MAX_BYTES.toLong()).string()
+        }.getOrNull() ?: return null
+        return parseGitLfsPointer(preview)
+    }
+
+    private fun Response.readGitLfsMarkdown(
+        source: RepositorySource,
+        accelerationSource: RepositoryAccelerationSource
+    ): String? {
+        val pointer = readGitLfsPointer() ?: return null
+        val download = resolveGitLfsDownload(source, pointer) ?: return null
+        buildLfsDownloadUrls(download.href, accelerationSource).forEach { url ->
+            val request = Request.Builder()
+                .url(url)
+                .apply {
+                    download.header?.forEach { (key, value) -> header(key, value) }
+                }
+                .build()
+            val result = downloadClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                response.body?.string()
             }
+            if (result != null) return result
+        }
+        return null
+    }
+
+    private fun parseGitLfsPointer(content: String): GitLfsPointer? {
+        val lines = content.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
+        if (lines.firstOrNull() != GIT_LFS_POINTER_PREFIX) return null
+
+        val oid = lines.firstOrNull { it.startsWith("oid sha256:") }
+            ?.removePrefix("oid sha256:")
+            ?.trim()
+            ?.takeIf { it.matches(Regex("^[0-9a-fA-F]{64}$")) }
+            ?: return null
+        val size = lines.firstOrNull { it.startsWith("size ") }
+            ?.removePrefix("size ")
+            ?.trim()
+            ?.toLongOrNull()
+            ?: return null
+        return GitLfsPointer(oid = oid, size = size)
+    }
+
+    private fun resolveGitLfsDownload(
+        source: RepositorySource,
+        pointer: GitLfsPointer
+    ): GitLfsDownloadAction? {
+        val requestBody = Gson().toJson(
+            GitLfsBatchRequest(
+                objects = listOf(
+                    GitLfsBatchObjectRequest(
+                        oid = pointer.oid,
+                        size = pointer.size
+                    )
+                )
+            )
+        ).toRequestBody(GIT_LFS_BATCH_MEDIA_TYPE)
+
+        val request = Request.Builder()
+            .url(source.lfsBatchUrl())
+            .header("Accept", "application/vnd.git-lfs+json")
+            .header("User-Agent", "AHUTong-Android")
+            .post(requestBody)
+            .build()
+
+        return downloadClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val batchResponse = runCatching {
+                gson.fromJson(response.body?.string().orEmpty(), GitLfsBatchResponse::class.java)
+            }.getOrNull()
+            batchResponse?.objects?.firstOrNull { it.oid.equals(pointer.oid, ignoreCase = true) }
+                ?.actions?.download
         }
     }
 
-    fun isDownloaded(path: String, context: Context): Boolean {
-        val localName = getDownloadedLocalName(path) ?: return false
-        return File(getDownloadDir(context), localName).exists()
-    }
-
-    suspend fun downloadFile(
-        repoId: String,
+    private suspend fun downloadGitLfsFile(
+        urls: List<String>,
+        headers: Map<String, String>?,
         path: String,
         context: Context,
-        onProgress: (Float) -> Unit = {}
-    ): File? = withContext(Dispatchers.IO) {
-        val localName = getLocalFileName(path)
-        val outFile = File(getDownloadDir(context), localName)
-        val urls = getDownloadUrls(repoId, path)
-
-        for ((index, url) in urls.withIndex()) {
-            try {
-                val request = Request.Builder().url(url).build()
-                val response = downloadClient.newCall(request).execute()
-                if (!response.isSuccessful) continue
-                val body = response.body ?: continue
-                val total = body.contentLength()
-
-                body.byteStream().use { input ->
-                    FileOutputStream(outFile).use { output ->
-                        val buffer = ByteArray(8 * 1024)
-                        var completed: Long = 0
-                        var read = input.read(buffer)
-                        while (read >= 0) {
-                            output.write(buffer, 0, read)
-                            completed += read
-                            if (total > 0) onProgress(completed.toFloat() / total.toFloat())
-                            read = input.read(buffer)
+        target: DownloadTarget,
+        previousRecord: DownloadRecord?,
+        pointer: GitLfsPointer,
+        onProgress: (Float) -> Unit
+    ): DownloadedFile? = withContext(Dispatchers.IO) {
+        urls.forEachIndexed { index, url ->
+            runCatching {
+                val request = Request.Builder().url(url).apply {
+                    headers?.forEach { (key, value) -> header(key, value) }
+                }.build()
+                downloadClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    val body = response.body ?: return@use null
+                    val total = body.contentLength().takeIf { it > 0L } ?: pointer.size
+                    var downloadedBytes = 0L
+                    body.byteStream().use { input ->
+                        target.openOutputStream().use { output ->
+                            val buffer = ByteArray(8 * 1024)
+                            var read = input.read(buffer)
+                            while (read >= 0) {
+                                output.write(buffer, 0, read)
+                                downloadedBytes += read
+                                if (total > 0L) {
+                                    onProgress(downloadedBytes.toFloat() / total.toFloat())
+                                }
+                                read = input.read(buffer)
+                            }
+                            output.flush()
                         }
-                        output.flush()
                     }
+                    target.markCompleted()
+                    if (target is DownloadTarget.MediaStoreTarget || previousRecord?.uri != null) {
+                        previousRecord?.delete(context)
+                    }
+                    removeDownloadRecord(path)
+                    val record = DownloadRecord(
+                        path = path,
+                        localName = target.relativePath,
+                        uri = target.uri?.toString(),
+                        localPath = target.displayPath,
+                        downloadTime = System.currentTimeMillis(),
+                        size = downloadedBytes.takeIf { it > 0L } ?: pointer.size
+                    )
+                    saveDownloadRecord(record)
+                    return@withContext record.toDownloadedFile(context)
                 }
-                saveDownloadRecord(path, localName)
-                return@withContext outFile
-            } catch (e: Exception) {
-                if (index == urls.lastIndex) {
-                    outFile.delete()
-                    return@withContext null
-                }
+            }.getOrNull()?.let { return@withContext it }
+
+            if (index == urls.lastIndex) {
+                return@withContext null
             }
         }
-        outFile.delete()
         null
     }
 
-    fun getLocalFile(path: String, context: Context): File? {
-        val localName = getDownloadedLocalName(path) ?: return null
-        val file = File(getDownloadDir(context), localName)
-        return if (file.exists()) file else null
+    private fun buildLfsDownloadUrls(
+        href: String,
+        accelerationSource: RepositoryAccelerationSource
+    ): List<String> {
+        val proxied = accelerationSource.proxyPrefix?.let { it + href }
+        return listOfNotNull(proxied, href).distinct()
     }
 
-    fun deleteFile(path: String, context: Context): Boolean {
-        val file = getLocalFile(path, context) ?: return false
-        val deleted = file.delete()
-        if (deleted) removeDownloadRecord(path)
-        return deleted
+    private fun matchesCurrentRepositorySources(items: List<GitHubContentItem>): Boolean {
+        val cachedRoots = items.map { it.path to it.name }
+        val expectedRoots = repositoryRootItems().map { it.path to it.name }
+        return cachedRoots == expectedRoots
     }
 
-    // === 内部方法 ===
+    private fun virtualPath(source: RepositorySource, repositoryPath: String): String {
+        val normalizedPath = normalizeRepositoryPath(repositoryPath)
+        return listOf(source.id, normalizedPath)
+            .filter { it.isNotEmpty() }
+            .joinToString("/")
+    }
 
-    private fun getDownloadedPaths(context: Context): List<Pair<String, String>> {
-        val json = kv.decodeString("downloaded_files", "[]") ?: "[]"
-        return try {
-            val type = object : TypeToken<List<List<String>>>() {}.type
-            val list: List<List<String>> = gson.fromJson(json, type)
-            list.mapNotNull { item -> if (item.size >= 2) Pair(item[0], item[1]) else null }
-        } catch (e: Exception) {
-            emptyList()
+    private fun resolveVirtualPath(path: String): ResolvedRepositoryPath? {
+        val normalizedPath = normalizeRepositoryPath(path)
+        if (normalizedPath.isEmpty()) return null
+        val repositoryId = normalizedPath.substringBefore('/')
+        val source = repositorySourceById[repositoryId] ?: return null
+        val repositoryPath = normalizedPath.substringAfter('/', "")
+        return ResolvedRepositoryPath(source, repositoryPath)
+    }
+
+    private fun repositoryRootUrl(): String {
+        return "$GITHUB_HOST/Kaltsit-cell/AHU-CS-Repository"
+    }
+
+    private suspend fun resolveRepositoryTreeSha(source: RepositorySource): String {
+        return withContext(Dispatchers.IO) {
+            val branchUrl = "https://api.github.com/repos/${source.owner}/${source.repo}/branches/${source.branch}"
+            val branchResponse = downloadClient.newCall(
+                Request.Builder()
+                    .url(branchUrl)
+                    .header("Accept", "application/vnd.github+json")
+                    .header("User-Agent", "AHUTong-Android")
+                    .build()
+            ).execute()
+            branchResponse.use { branch ->
+                if (!branch.isSuccessful) {
+                    throw IllegalStateException("无法获取仓库树")
+                }
+                val treeJson = branch.body?.string().orEmpty()
+                val treeMatcher = Regex("\"tree\"\\s*:\\s*\\{\\s*\"sha\"\\s*:\\s*\"([0-9a-fA-F]{40})\"")
+                    .find(treeJson)
+                treeMatcher?.groupValues?.getOrNull(1)
+                    ?: throw IllegalStateException("无法解析仓库树")
+            }
         }
     }
 
-    private fun getDownloadedLocalName(path: String): String? {
-        val files = getDownloadedPaths(AHUApplication.getApp())
-        return files.firstOrNull { it.first == path }?.second
+    private fun getUnsupportedDirectoryPaths(): Set<String> {
+        val json = kv.decodeString(CONTENT_UNSUPPORTED_PATHS_KEY, "[]") ?: "[]"
+        return try {
+            val type = object : TypeToken<List<String>>() {}.type
+            gson.fromJson<List<String>>(json, type).toSet()
+        } catch (e: Exception) {
+            emptySet()
+        }
     }
 
-    private fun saveDownloadRecord(path: String, localName: String) {
-        val files = getDownloadedPaths(AHUApplication.getApp()).toMutableList()
-        files.removeAll { it.first == path }
-        files.add(Pair(path, localName))
-        kv.encode("downloaded_files", gson.toJson(files.map { listOf(it.first, it.second) }))
+    private fun saveUnsupportedDirectoryPaths(paths: Set<String>) {
+        kv.encode(CONTENT_UNSUPPORTED_PATHS_KEY, gson.toJson(paths.sorted()))
     }
 
-    private fun removeDownloadRecord(path: String) {
-        val files = getDownloadedPaths(AHUApplication.getApp()).toMutableList()
-        files.removeAll { it.first == path }
-        kv.encode("downloaded_files", gson.toJson(files.map { listOf(it.first, it.second) }))
-    }
-
-    private fun saveContentCache(repoId: String, path: String, items: List<GitHubContentItem>) {
-        val key = contentCacheKey(repoId, path)
-        kv.encode("${contentCachePrefix(repoId)}$key", gson.toJson(items))
-        kv.encode("${contentCacheTimePrefix(repoId)}$key", System.currentTimeMillis())
-    }
-
-    private fun getLocalFileName(path: String): String {
-        val sourceName = File(path).name.ifEmpty { "repository_file" }
-        val dotIndex = sourceName.lastIndexOf('.')
-        val nameWithoutExtension = if (dotIndex > 0) sourceName.substring(0, dotIndex) else sourceName
-        val extension = if (dotIndex > 0) sourceName.substring(dotIndex) else ""
-        val pathHash = Integer.toHexString(path.hashCode())
-        return "${nameWithoutExtension}_$pathHash$extension"
+    private fun normalizeRepositoryPath(path: String): String {
+        return path.replace('\\', '/').trim('/')
     }
 
     private fun encodePath(path: String): String {
         if (path.isEmpty()) return ""
         return path.split('/').joinToString("/") { Uri.encode(it) }
     }
+
+    private fun contentCacheKey(path: String): String {
+        return Base64.encodeToString(
+            path.toByteArray(Charsets.UTF_8),
+            Base64.NO_WRAP or Base64.URL_SAFE
+        )
+    }
+
+    private data class DownloadRecord(
+        val path: String,
+        val localName: String,
+        val uri: String? = null,
+        val localPath: String? = null,
+        val downloadTime: Long = 0L,
+        val size: Long = 0L
+    ) {
+        fun toDownloadedFile(context: Context): DownloadedFile? {
+            val uriValue = uri?.let { Uri.parse(it) }
+            if (uriValue != null) {
+                return DownloadedFile(
+                    name = File(path).name,
+                    path = path,
+                    localPath = localPath ?: localName,
+                    size = size.takeIf { it > 0L } ?: querySize(uriValue),
+                    downloadTime = downloadTime,
+                    uri = uri
+                )
+            }
+
+            val file = File(localPath ?: File(getLegacyDownloadDir(context), localName).absolutePath)
+            if (!file.exists()) return null
+            return DownloadedFile(
+                name = File(path).name,
+                path = path,
+                localPath = file.absolutePath,
+                size = size.takeIf { it > 0L } ?: file.length(),
+                downloadTime = if (downloadTime > 0) downloadTime else file.lastModified()
+            )
+        }
+
+        fun delete(context: Context): Boolean {
+            val uriValue = uri?.let { Uri.parse(it) }
+            if (uriValue != null) {
+                return context.contentResolver.delete(uriValue, null, null) > 0
+            }
+
+            val file = File(localPath ?: File(getLegacyDownloadDir(context), localName).absolutePath)
+            return !file.exists() || file.delete()
+        }
+
+        private fun querySize(uri: Uri): Long {
+            return runCatching {
+                val context = AHUApplication.getApp()
+                context.contentResolver.query(
+                    uri,
+                    arrayOf(OpenableColumns.SIZE),
+                    null,
+                    null,
+                    null
+                )?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                        if (sizeIndex >= 0) cursor.getLong(sizeIndex) else 0L
+                    } else {
+                        0L
+                    }
+                } ?: 0L
+            }.getOrDefault(0L)
+        }
+    }
+
+    private sealed class DownloadTarget(
+        val relativePath: String,
+        val displayPath: String,
+        val uri: Uri?
+    ) {
+        abstract fun openOutputStream(): OutputStream
+        open fun markCompleted() = Unit
+        abstract fun delete()
+
+        class MediaStoreTarget(
+            private val context: Context,
+            uri: Uri,
+            relativePath: String,
+            displayPath: String
+        ) : DownloadTarget(relativePath, displayPath, uri) {
+            override fun openOutputStream(): OutputStream {
+                return context.contentResolver.openOutputStream(uri!!)
+                    ?: throw IllegalStateException("无法写入下载文件")
+            }
+
+            override fun markCompleted() {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    val values = ContentValues().apply {
+                        put(MediaStore.MediaColumns.IS_PENDING, 0)
+                    }
+                    context.contentResolver.update(uri!!, values, null, null)
+                }
+            }
+
+            override fun delete() {
+                context.contentResolver.delete(uri!!, null, null)
+            }
+        }
+
+        class FileTarget(
+            private val file: File,
+            relativePath: String
+        ) : DownloadTarget(relativePath, file.absolutePath, null) {
+            private val tempFile = File(file.parentFile, "${file.name}.downloading")
+
+            override fun openOutputStream(): OutputStream {
+                tempFile.parentFile?.mkdirs()
+                return FileOutputStream(tempFile)
+            }
+
+            override fun markCompleted() {
+                if (file.exists()) {
+                    file.delete()
+                }
+                if (!tempFile.renameTo(file)) {
+                    tempFile.copyTo(file, overwrite = true)
+                    tempFile.delete()
+                }
+            }
+
+            override fun delete() {
+                tempFile.delete()
+            }
+        }
+    }
+
+    private data class RepositorySource(
+        val id: String,
+        val title: String,
+        val owner: String,
+        val repo: String,
+        val branch: String
+    ) {
+        fun rawUrl(repositoryPath: String): String {
+            return "$RAW_HOST/$owner/$repo/$branch/${encodePath(repositoryPath)}"
+        }
+
+        fun cdnUrl(repositoryPath: String): String {
+            return "$CDN_HOST/$owner/$repo@$branch/${encodePath(repositoryPath)}"
+        }
+
+        fun githubUrl(repositoryPath: String, tree: Boolean): String {
+            val kind = if (tree) "tree" else "blob"
+            val encodedPath = encodePath(repositoryPath)
+            return if (encodedPath.isEmpty()) {
+                "$GITHUB_HOST/$owner/$repo/tree/$branch"
+            } else {
+                "$GITHUB_HOST/$owner/$repo/$kind/$branch/$encodedPath"
+            }
+        }
+
+        fun lfsBatchUrl(): String {
+            return "$GITHUB_HOST/$owner/$repo.git/info/lfs/objects/batch"
+        }
+    }
+
+    private data class ResolvedRepositoryPath(
+        val source: RepositorySource,
+        val repositoryPath: String
+    )
+
+    private data class RepositoryIndexCache(
+        val grouped: Map<String, List<GitHubContentItem>>,
+        val unsupportedDirectoryPaths: Set<String>,
+        val documentFileCount: Int
+    )
+
+    private data class GitLfsPointer(
+        val oid: String,
+        val size: Long
+    )
+
+    private data class GitLfsBatchRequest(
+        val operation: String = "download",
+        val transfers: List<String> = listOf("basic"),
+        val objects: List<GitLfsBatchObjectRequest>
+    )
+
+    private data class GitLfsBatchObjectRequest(
+        val oid: String,
+        val size: Long
+    )
+
+    private data class GitLfsBatchResponse(
+        val objects: List<GitLfsBatchObjectResponse> = emptyList()
+    )
+
+    private data class GitLfsBatchObjectResponse(
+        val oid: String,
+        val size: Long = 0,
+        val actions: GitLfsBatchActions? = null
+    )
+
+    private data class GitLfsBatchActions(
+        val download: GitLfsDownloadAction? = null
+    )
+
+    private data class GitLfsDownloadAction(
+        val href: String,
+        val header: Map<String, String>? = null
+    )
 }

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/Main.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/Main.kt
@@ -25,7 +25,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
 import androidx.navigation.NavHostController
+import androidx.navigation.navArgument
 import androidx.navigation.compose.NavHost
 import com.ahu.ahutong.appwidget.ScheduleAppWidgetReceiver
 import com.ahu.ahutong.data.gray.GrayFeatures
@@ -40,10 +42,14 @@ import com.ahu.ahutong.ui.screen.main.Home
 import com.ahu.ahutong.ui.screen.main.LostFound
 import com.ahu.ahutong.ui.screen.main.PhoneBook
 import com.ahu.ahutong.ui.screen.main.Schedule
+import com.ahu.ahutong.ui.screen.main.REPOSITORY_DIRECTORY_ROUTE
+import com.ahu.ahutong.ui.screen.main.REPOSITORY_PATH_ARG
+import com.ahu.ahutong.ui.screen.main.REPOSITORY_ROUTE
 import com.ahu.ahutong.ui.screen.main.SchoolCalendar
 import com.ahu.ahutong.ui.screen.main.Tools
 import com.ahu.ahutong.ui.screen.main.Repository
 import com.ahu.ahutong.ui.screen.main.RepositoryDownloads
+import com.ahu.ahutong.ui.screen.main.RepositorySettings
 import com.ahu.ahutong.ui.screen.main.Weather
 import com.ahu.ahutong.ui.screen.settings.Contributors
 import com.ahu.ahutong.ui.screen.settings.Debug
@@ -187,11 +193,32 @@ fun Main(
             animatedComposable("weather") {
                 Weather()
             }
-            animatedComposable("repository") {
-                Repository(navController = navController)
+            animatedComposable(REPOSITORY_ROUTE) {
+                Repository(
+                    navController = navController,
+                    path = ""
+                )
+            }
+            animatedComposable(
+                route = REPOSITORY_DIRECTORY_ROUTE,
+                arguments = listOf(
+                    navArgument(REPOSITORY_PATH_ARG) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = ""
+                    }
+                )
+            ) { backStackEntry ->
+                Repository(
+                    navController = navController,
+                    path = backStackEntry.arguments?.getString(REPOSITORY_PATH_ARG).orEmpty()
+                )
             }
             animatedComposable("repository_downloads") {
                 RepositoryDownloads(navController = navController)
+            }
+            animatedComposable("repository_settings") {
+                RepositorySettings(navController = navController)
             }
             animatedComposable("settings") {
                 Settings(

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/Repository.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/Repository.kt
@@ -496,6 +496,11 @@ private fun RepositoryItemRow(
         fileAccentColor.copy(alpha = 0.14f)
     }
     val fileBadgeTextColor = if (isDark) Color.White else fileAccentColor
+    val secondaryTextColor = if (isDark) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
     Row(
         modifier = Modifier
@@ -570,7 +575,7 @@ private fun RepositoryItemRow(
                     formatSize(item.size)
                 },
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = secondaryTextColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -701,8 +706,13 @@ internal fun formatSize(bytes: Long): String {
 
 @Composable
 private fun RepositoryFooter() {
+    val isDark = isSystemInDarkTheme()
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val textColor = if (isDark) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
     val linkColor = Color(0xFF42A5F5)
 
     Row(

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/Repository.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/Repository.kt
@@ -1,8 +1,14 @@
 package com.ahu.ahutong.ui.screen.main
 
-import androidx.activity.compose.BackHandler
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.text.method.LinkMovementMethod
+import android.widget.ScrollView
+import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,55 +23,82 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.TaskAlt
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.ahu.ahutong.data.repository.GitHubContentItem
-import com.ahu.ahutong.data.repository.RepoConfig
+import com.ahu.ahutong.data.repository.RepositoryDirectorySummary
 import com.ahu.ahutong.data.repository.RepositoryManager
-import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
+import com.ahu.ahutong.ui.state.RepositoryMarkdownUiState
 import com.ahu.ahutong.ui.state.RepositoryViewModel
-import com.kyant.monet.a1
 import com.kyant.monet.n1
 import com.kyant.monet.withNight
+import io.noties.markwon.Markwon
+import kotlinx.coroutines.flow.collect
 
 @Composable
 fun Repository(
-    navController: NavHostController
+    navController: NavHostController,
+    path: String
 ) {
     val activity = LocalContext.current as androidx.activity.ComponentActivity
     val viewModel: RepositoryViewModel = viewModel(viewModelStoreOwner = activity)
-    val state by viewModel.uiState.collectAsState()
+    val directoryStates by viewModel.directoryStates.collectAsState()
+    val sharedState by viewModel.sharedState.collectAsState()
+    val markdownState by viewModel.markdownState.collectAsState()
+    val state = directoryStates[path] ?: viewModel.getDirectoryState(path)
+    val initialScrollPosition = viewModel.getScrollPosition(path)
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = initialScrollPosition.index,
+        initialFirstVisibleItemScrollOffset = initialScrollPosition.offset
+    )
+    val shouldShowInitialProgress = path.isBlank() && state.items.isEmpty() && sharedState.isCacheWarming
 
-    val onRepoSelector = state.selectedRepoId == null && state.items.isEmpty()
-    BackHandler(enabled = !onRepoSelector) {
-        if (!viewModel.goBack()) viewModel.resetToRepoSelector()
+    LaunchedEffect(path) {
+        viewModel.ensureLoaded(path)
+        viewModel.warmUpAllContentCaches()
+    }
+
+    LaunchedEffect(listState, path) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        }.collect { (index, offset) ->
+            viewModel.saveScrollPosition(path, index, offset)
+        }
     }
 
     Column(
@@ -74,275 +107,643 @@ fun Repository(
             .systemBarsPadding()
             .background(96.n1 withNight 10.n1)
     ) {
-        // 顶部栏
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 12.dp),
+                .padding(horizontal = 8.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconButton(onClick = {
-                if (!viewModel.goBack()) {
-                    if (state.selectedRepoId != null) viewModel.resetToRepoSelector()
-                    else navController.popBackStack()
-                }
-            }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "返回")
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "返回"
+                )
             }
             Text(
-                text = when {
-                    state.selectedRepoId != null -> {
-                        val repo = RepositoryManager.getRepo(state.selectedRepoId!!)
-                        if (state.currentPath.isEmpty()) repo.name
-                        else state.currentPath.substringAfterLast('/')
-                    }
-                    else -> "学习资料"
-                },
+                text = "学习资料",
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.weight(1f)
             )
-            if (state.selectedRepoId != null && state.isRefreshing) {
-                CircularProgressIndicator(modifier = Modifier.padding(horizontal = 12.dp).size(22.dp), strokeWidth = 2.dp)
-            } else if (state.selectedRepoId != null) {
-                IconButton(onClick = { viewModel.refreshCurrentDirectory() }) {
-                    Icon(Icons.Outlined.Refresh, "刷新")
-                }
-            }
-            TextButton(onClick = { navController.navigate("repository_downloads") }) { Text("已下载") }
-        }
-
-        // 学院选择（顶层 → 文件夹形式）
-        if (onRepoSelector) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                items(RepositoryManager.repositories) { repo ->
-                    RepoItem(repo) { viewModel.selectRepo(repo.id) }
-                }
-                item { Spacer(Modifier.height(80.dp)) }
-            }
-            return@Column
-        }
-
-        // 路径面包屑
-        if (state.currentPath.isNotEmpty()) {
-            Text(
-                text = state.currentPath,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
-                maxLines = 1, overflow = TextOverflow.Ellipsis
+            RepositoryRefreshButton(
+                loading = state.isLoading || state.isRefreshing || sharedState.isCacheWarming,
+                onRefresh = { viewModel.refreshDirectory(path) }
             )
+            IconButton(onClick = { navController.navigate("repository_downloads") }) {
+                Icon(
+                    imageVector = Icons.Outlined.Download,
+                    contentDescription = "已下载",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            IconButton(onClick = { navController.navigate("repository_settings") }) {
+                Icon(
+                    imageVector = Icons.Outlined.Tune,
+                    contentDescription = "学习资料设置"
+                )
+            }
         }
 
-        RepositorySyncStatus(
-            pendingPath = state.pendingPath,
-            isRefreshing = state.isRefreshing && state.items.isNotEmpty(),
-            isShowingCachedContents = state.isShowingCachedContents,
-            cacheUpdatedAt = state.cacheUpdatedAt
+        RepositoryBreadcrumb(
+            currentPath = path,
+            onPathClick = { targetPath ->
+                popToRepositoryPath(
+                    navController = navController,
+                    currentPath = path,
+                    targetPath = targetPath
+                )
+            }
         )
 
         state.error?.let { error ->
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
-                    .clip(RoundedCornerShape(12.dp)).background(Color(0x33FF5252)).padding(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 8.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(0x33FF5252))
+                    .clickable { viewModel.clearError(path) }
+                    .padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(error, color = Color(0xFFFF5252), style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
-                TextButton(onClick = { viewModel.clearError() }) { Text("关闭", color = Color(0xFFFF5252)) }
+                Text(
+                    text = error,
+                    color = Color(0xFFFF5252),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = "关闭",
+                    color = Color(0xFFFF5252),
+                    style = MaterialTheme.typography.labelMedium
+                )
             }
         }
 
-        if (state.isLoading && state.items.isEmpty()) {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
-        } else {
-            LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                items(state.items, key = { it.path }) { item ->
-                    RepositoryItemRow(
-                        item = item,
-                        isNavigationEnabled = state.pendingPath == null,
-                        isDownloaded = item.path in state.downloadedPaths,
-                        isDownloading = item.path in state.downloadingPaths,
-                        progress = state.downloadProgress[item.path] ?: 0f,
-                        onItemClick = { if (item.type == "dir") viewModel.enterDirectory(item) },
-                        onDownload = { viewModel.downloadFile(item) },
-                        onOpen = { viewModel.openFile(item) }
-                    )
+        Box(
+            modifier = Modifier.weight(1f)
+        ) {
+            if (shouldShowInitialProgress) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background((96.n1 withNight 10.n1).copy(alpha = 0.96f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                        Text(
+                            text = "已获取 ${sharedState.cacheWarmUpCount} 个文件",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "正在整理学习资料目录",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
-                if (state.items.isEmpty() && !state.isLoading) {
-                    item {
-                        Box(Modifier.fillMaxWidth().padding(48.dp), contentAlignment = Alignment.Center) {
-                            Text("此目录为空", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    items(state.items, key = { it.path }) { item ->
+                        RepositoryItemRow(
+                            item = item,
+                            isDownloaded = item.path in sharedState.downloadedPaths,
+                            isDownloading = item.path == sharedState.downloadingPath,
+                            progress = sharedState.downloadProgress[item.path] ?: 0f,
+                            directorySummary = state.directorySummaries[item.path],
+                            onItemClick = {
+                                if (item.type == "dir") {
+                                    navController.navigateRepository(item.path)
+                                }
+                            },
+                            onDownload = { viewModel.downloadFile(item) },
+                            onOpen = { viewModel.openFile(item) }
+                        )
+                    }
+
+                    if (state.items.isEmpty() && !state.isLoading) {
+                        item {
+                            RepositoryEmptyDirectoryMessage(
+                                showGithubLink = viewModel.shouldShowUnsupportedDirectoryMessage(path),
+                                onGithubClick = { openExternalUrl(viewModel.getGitHubUrl(path), activity) }
+                            )
+                        }
+                    } else if (state.items.isEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(32.dp))
+                        }
+                    }
+
+                    if (!state.isLoading && state.items.isNotEmpty()) {
+                        item {
+                            RepositoryFooter()
                         }
                     }
                 }
-                if (!state.isLoading && state.items.isNotEmpty()) {
-                    item {
-                        val repoUrl = RepositoryManager.getRepoUrl(state.selectedRepoId ?: "")
-                        RepositoryFooter(repoUrl)
-                    }
-                }
             }
         }
     }
-}
 
-@Composable
-private fun RepoItem(repo: RepoConfig, onClick: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(SmoothRoundedCornerShape(16.dp))
-            .background(100.n1 withNight 30.n1)
-            .clickable { onClick() }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.Folder,
-            contentDescription = null,
-            tint = Color(0xFFFFB300),
-            modifier = Modifier.size(28.dp)
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Text(repo.name, style = MaterialTheme.typography.bodyLarge)
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(repo.repo, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
-    }
-}
-
-@Composable
-private fun RepositorySyncStatus(
-    pendingPath: String?, isRefreshing: Boolean, isShowingCachedContents: Boolean, cacheUpdatedAt: Long?
-) {
-    val text = when {
-        pendingPath != null -> "正在打开 ${pendingPath.substringAfterLast('/')}"
-        isRefreshing -> "正在同步 GitHub 最新目录"
-        isShowingCachedContents -> {
-            val cacheTime = formatCacheAge(cacheUpdatedAt)
-            if (cacheTime.isEmpty()) "GitHub 连接失败，当前显示上次缓存"
-            else "GitHub 连接失败，当前显示 $cacheTime 的缓存"
-        }
-        else -> return
-    }
-    val backgroundColor = if (isRefreshing) Color(0x2233A1FD) else Color(0x33FFB300)
-    val textColor = if (isRefreshing) Color(0xFF1976D2) else Color(0xFF8A5A00)
-    Text(
-        text = text,
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp)
-            .clip(RoundedCornerShape(12.dp)).background(backgroundColor).padding(horizontal = 12.dp, vertical = 8.dp),
-        color = textColor, style = MaterialTheme.typography.bodySmall
+    RepositoryMarkdownReader(
+        markdownState = markdownState,
+        onDismiss = { viewModel.clearMarkdown() }
     )
 }
 
 @Composable
-private fun RepositoryItemRow(
-    item: GitHubContentItem, isNavigationEnabled: Boolean, isDownloaded: Boolean,
-    isDownloading: Boolean, progress: Float, onItemClick: () -> Unit, onDownload: () -> Unit, onOpen: () -> Unit
+internal fun RepositoryMarkdownReader(
+    markdownState: RepositoryMarkdownUiState,
+    onDismiss: () -> Unit
 ) {
-    val isDir = item.type == "dir"
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp)
-            .clip(SmoothRoundedCornerShape(16.dp)).background(100.n1 withNight 30.n1)
-            .clickable(enabled = isDir && isNavigationEnabled) { onItemClick() }
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            if (isDir) {
-                Icon(Icons.Outlined.Folder, null, tint = Color(0xFFFFB300), modifier = Modifier.size(28.dp))
-            } else {
-                val typeLabel = RepositoryViewModel.getFileTypeIcon(item.name)
-                Box(
-                    Modifier.size(32.dp).clip(RoundedCornerShape(6.dp)).background(
-                        when (typeLabel) {
-                                "PDF" -> Color(0xFFE53935); "DOC" -> Color(0xFF1565C0)
-                                "PPT" -> Color(0xFFE65100); "XLS" -> Color(0xFF2E7D32)
-                                "IMG" -> Color(0xFF8E24AA); "SVG" -> Color(0xFFFF7043)
-                                "ZIP" -> Color(0xFF795548); "APK" -> Color(0xFF009688)
-                                else -> Color(0xFF757575)
+    if (!markdownState.isLoading && markdownState.document == null && markdownState.error == null) {
+        return
+    }
+
+    val context = LocalContext.current
+    val markwon = remember(context) { Markwon.create(context) }
+    val markdownTextColor = MaterialTheme.colorScheme.onSurface.toArgb()
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .background(96.n1 withNight 16.n1)
+                .padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = markdownState.document?.title ?: "Markdown",
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    "关闭",
+                    color = Color(0xFF42A5F5),
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier
+                        .clickable { onDismiss() }
+                        .padding(horizontal = 8.dp, vertical = 6.dp)
+                )
+            }
+
+            when {
+                markdownState.isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(160.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                    }
+                }
+                markdownState.error != null -> {
+                    Text(
+                        text = markdownState.error,
+                        color = Color(0xFFFF5252),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                markdownState.document != null -> {
+                    AndroidView(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(420.dp),
+                        factory = { viewContext ->
+                            ScrollView(viewContext).apply {
+                                addView(
+                                    TextView(viewContext).apply {
+                                        movementMethod = LinkMovementMethod.getInstance()
+                                        setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 15f)
+                                        setPadding(0, 0, 0, 0)
+                                    }
+                                )
                             }
-                    ), contentAlignment = Alignment.Center
-                ) {
-                    Text(typeLabel, style = MaterialTheme.typography.labelSmall, color = Color.White, fontWeight = FontWeight.Bold)
-                }
-            }
-            Spacer(Modifier.width(12.dp))
-            Column(Modifier.weight(1f)) {
-                Text(item.name, style = MaterialTheme.typography.bodyLarge, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                if (!isDir && item.size > 0) {
-                    Text(formatSize(item.size), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-            }
-            if (!isDir) {
-                if (isDownloading) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(start = 8.dp)) {
-                        CircularProgressIndicator(progress = { progress }, modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
-                        Text("${(progress * 100).toInt()}%", style = MaterialTheme.typography.labelSmall)
-                    }
-                } else if (isDownloaded) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Outlined.TaskAlt, "已下载", tint = Color(0xFF4CAF50), modifier = Modifier.size(20.dp))
-                            Spacer(Modifier.width(4.dp))
-                            Text("已下载", style = MaterialTheme.typography.labelSmall, color = Color(0xFF4CAF50))
+                        },
+                        update = { scrollView ->
+                            val textView = scrollView.getChildAt(0) as TextView
+                            textView.setTextColor(markdownTextColor)
+                            markwon.setMarkdown(textView, markdownState.document.content)
                         }
-                        TextButton(onClick = onOpen, contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 8.dp)) {
-                            Text("打开", style = MaterialTheme.typography.labelSmall)
-                        }
-                    }
-                } else {
-                    IconButton(onClick = onDownload, modifier = Modifier.size(36.dp)) {
-                        Icon(Icons.Outlined.CloudDownload, "下载", tint = Color(0xFF42A5F5), modifier = Modifier.size(22.dp))
-                    }
+                    )
                 }
             }
         }
-        if (isDownloading && progress > 0f && progress < 1f) {
-            LinearProgressIndicator(
-                progress = { progress },
-                modifier = Modifier.fillMaxWidth().padding(top = 8.dp).height(3.dp).clip(RoundedCornerShape(2.dp))
+    }
+}
+
+@Composable
+private fun RepositoryRefreshButton(
+    loading: Boolean,
+    onRefresh: () -> Unit
+) {
+    IconButton(
+        onClick = onRefresh,
+        enabled = !loading,
+        modifier = Modifier.size(40.dp)
+    ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Outlined.Refresh,
+                contentDescription = "刷新"
             )
         }
     }
 }
 
-internal fun formatSize(bytes: Long): String = when {
-    bytes < 1024 -> "${bytes}B"
-    bytes < 1024 * 1024 -> "${bytes / 1024}KB"
-    bytes < 1024 * 1024 * 1024 -> "${bytes / (1024 * 1024)}MB"
-    else -> "${bytes / (1024 * 1024 * 1024)}GB"
-}
+@Composable
+private fun RepositoryBreadcrumb(
+    currentPath: String,
+    onPathClick: (String) -> Unit
+) {
+    val isDark = isSystemInDarkTheme()
+    val segments = currentPath.split('/').filter { it.isNotEmpty() }
+    val scrollState = rememberScrollState()
+    val chipColor = if (isDark) {
+        Color.White.copy(alpha = 0.08f)
+    } else {
+        Color(0xFFF5F6FB)
+    }
+    val selectedChipColor = if (isDark) {
+        MaterialTheme.colorScheme.primary.copy(alpha = 0.22f)
+    } else {
+        Color(0xFFFFF1C8)
+    }
+    val selectedTextColor = if (isDark) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        Color(0xFFDA9A00)
+    }
+    val paths = buildList {
+        add("学习资料" to "")
+        if (segments.isNotEmpty()) {
+            val repositoryId = segments.first()
+            val repositoryTitle = RepositoryManager.getRepositoryTitle(repositoryId)
+            add(repositoryTitle to repositoryId)
 
-private fun formatCacheAge(cacheUpdatedAt: Long?): String {
-    if (cacheUpdatedAt == null || cacheUpdatedAt <= 0L) return ""
-    val diffMillis = (System.currentTimeMillis() - cacheUpdatedAt).coerceAtLeast(0L)
-    val minutes = diffMillis / (60 * 1000); val hours = minutes / 60; val days = hours / 24
-    return when {
-        minutes < 1 -> "刚刚"; minutes < 60 -> "${minutes}分钟前"
-        hours < 24 -> "${hours}小时前"; else -> "${days}天前"
+            val actualRelativeSegments = segments.drop(1)
+            val visibleRelativeSegments = if (actualRelativeSegments.firstOrNull() == repositoryTitle) {
+                actualRelativeSegments.drop(1)
+            } else {
+                actualRelativeSegments
+            }
+
+            visibleRelativeSegments.indices.forEach { index ->
+                val visibleCount = index + 1
+                val actualCount = if (actualRelativeSegments.firstOrNull() == repositoryTitle) {
+                    visibleCount + 1
+                } else {
+                    visibleCount
+                }
+                val actualPath = buildString {
+                    append(repositoryId)
+                    actualRelativeSegments.take(actualCount).forEach { segment ->
+                        append('/')
+                        append(segment)
+                    }
+                }
+                add(visibleRelativeSegments[index] to actualPath)
+            }
+        }
+    }
+
+    LaunchedEffect(currentPath, scrollState.maxValue) {
+        scrollState.scrollTo(scrollState.maxValue)
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scrollState)
+            .padding(horizontal = 18.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        paths.forEachIndexed { index, (label, path) ->
+            val selected = path == currentPath
+            Text(
+                text = label,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(if (selected) selectedChipColor else chipColor)
+                    .clickable(enabled = !selected) { onPathClick(path) }
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                color = if (selected) {
+                    selectedTextColor
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (index < paths.lastIndex) {
+                Text(
+                    text = "›",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+        }
     }
 }
 
 @Composable
-private fun RepositoryFooter(repoUrl: String) {
+private fun RepositoryItemRow(
+    item: GitHubContentItem,
+    isDownloaded: Boolean,
+    isDownloading: Boolean,
+    progress: Float,
+    directorySummary: RepositoryDirectorySummary?,
+    onItemClick: () -> Unit,
+    onDownload: () -> Unit,
+    onOpen: () -> Unit
+) {
+    val isDark = isSystemInDarkTheme()
+    val isDir = item.type == "dir"
+    val isMarkdown = RepositoryViewModel.isMarkdownFile(item.name)
+    val rowEnabled = isDir || isDownloaded || isMarkdown
+    val fileAccentColor = when (RepositoryViewModel.getFileTypeIcon(item.name)) {
+        "PDF" -> Color(0xFFE53935)
+        "DOC" -> Color(0xFF1565C0)
+        "PPT" -> Color(0xFFE65100)
+        "XLS" -> Color(0xFF2E7D32)
+        else -> Color(0xFF757575)
+    }
+    val fileBadgeColor = if (isDark) {
+        fileAccentColor.copy(alpha = 0.88f)
+    } else {
+        fileAccentColor.copy(alpha = 0.14f)
+    }
+    val fileBadgeTextColor = if (isDark) Color.White else fileAccentColor
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 18.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .clickable(enabled = rowEnabled) {
+                if (isDir) {
+                    onItemClick()
+                } else {
+                    onOpen()
+                }
+            }
+            .padding(horizontal = 6.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isDir) {
+            Icon(
+                imageVector = Icons.Outlined.Folder,
+                contentDescription = null,
+                tint = Color(0xFFFFB300),
+                modifier = Modifier.size(42.dp)
+            )
+        } else {
+            val typeLabel = RepositoryViewModel.getFileTypeIcon(item.name)
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(fileBadgeColor),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = typeLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = fileBadgeTextColor,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(18.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (!isDir && isDownloaded) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Icon(
+                        imageVector = Icons.Outlined.TaskAlt,
+                        contentDescription = "已下载",
+                        tint = Color(0xFF4CAF50),
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+            Text(
+                text = if (isDir) {
+                    directorySummary?.let {
+                        "${it.directoryCount} 个目录 | ${it.fileCount} 个文件"
+                    } ?: "目录"
+                } else {
+                    formatSize(item.size)
+                },
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .width(44.dp)
+                .padding(start = 6.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            when {
+                isDir -> {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                isDownloading -> {
+                    CircularProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.5.dp
+                    )
+                }
+                isDownloaded -> {
+                    IconButton(onClick = onOpen, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                            contentDescription = "打开",
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                }
+                else -> {
+                    IconButton(onClick = onDownload, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            imageVector = Icons.Outlined.Download,
+                            contentDescription = "下载",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RepositoryEmptyDirectoryMessage(
+    showGithubLink: Boolean,
+    onGithubClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 48.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        if (showGithubLink) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    "文件夹内包含的文件不是文档格式，如需查看，请前往",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "GitHub",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color(0xFF42A5F5),
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.clickable { onGithubClick() }
+                )
+            }
+        } else {
+            Text(
+                "此目录为空",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun openExternalUrl(url: String, context: Context) {
+    if (url.isBlank()) return
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}
+
+private fun popToRepositoryPath(
+    navController: NavHostController,
+    currentPath: String,
+    targetPath: String
+) {
+    if (targetPath == currentPath) return
+    val currentSegments = currentPath.split('/').filter { it.isNotEmpty() }
+    val targetSegments = targetPath.split('/').filter { it.isNotEmpty() }
+    val isAncestor = targetSegments.size <= currentSegments.size &&
+        currentSegments.take(targetSegments.size) == targetSegments
+
+    if (isAncestor) {
+        repeat(currentSegments.size - targetSegments.size) {
+            navController.popBackStack()
+        }
+        return
+    }
+
+    navController.navigateRepository(targetPath)
+}
+
+internal fun formatSize(bytes: Long): String {
+    return when {
+        bytes < 1024 -> "${bytes}B"
+        bytes < 1024 * 1024 -> "${bytes / 1024}KB"
+        bytes < 1024 * 1024 * 1024 -> "${bytes / (1024 * 1024)}MB"
+        else -> "${bytes / (1024 * 1024 * 1024)}GB"
+    }
+}
+
+@Composable
+private fun RepositoryFooter() {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onSurfaceVariant; val linkColor = Color(0xFF42A5F5)
-    Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp), horizontalArrangement = Arrangement.Center) {
-        Text("发现新资料？向", style = MaterialTheme.typography.bodySmall, color = textColor)
-        Text("GitHub 仓库", style = MaterialTheme.typography.bodySmall, color = linkColor,
+    val textColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val linkColor = Color(0xFF42A5F5)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            "发现新资料？向",
+            style = MaterialTheme.typography.bodySmall,
+            color = textColor
+        )
+        Text(
+            "GitHub 仓库",
+            style = MaterialTheme.typography.bodySmall,
+            color = linkColor,
             modifier = Modifier.clickable {
-                context.startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(repoUrl))
-                    .apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) })
-            })
-        Text("提 PR 或向开发者", style = MaterialTheme.typography.bodySmall, color = textColor)
-        Text("联系", style = MaterialTheme.typography.bodySmall, color = linkColor,
+                val intent = android.content.Intent(
+                    android.content.Intent.ACTION_VIEW,
+                    android.net.Uri.parse("https://github.com/Kaltsit-cell/AHU-CS-Repository")
+                ).apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
+                context.startActivity(intent)
+            }
+        )
+        Text(
+            "提 PR 或向开发者",
+            style = MaterialTheme.typography.bodySmall,
+            color = textColor
+        )
+        Text(
+            "联系",
+            style = MaterialTheme.typography.bodySmall,
+            color = linkColor,
             modifier = Modifier.clickable {
-                context.startActivity(android.content.Intent(android.content.Intent.ACTION_SENDTO).apply {
+                val intent = android.content.Intent(android.content.Intent.ACTION_SENDTO).apply {
                     data = android.net.Uri.parse("mailto:1793838025@qq.com")
                     addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                })
-            })
-        Text("资料", style = MaterialTheme.typography.bodySmall, color = textColor)
+                }
+                context.startActivity(intent)
+            }
+        )
     }
 }

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryDownloads.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryDownloads.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +48,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.ahu.ahutong.data.repository.DownloadedFile
+import com.ahu.ahutong.data.repository.RepositoryManager
 import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
 import com.ahu.ahutong.ui.state.RepositoryViewModel
 import com.kyant.monet.a1
@@ -60,6 +62,7 @@ fun RepositoryDownloads(
     val context = LocalContext.current
     val activity = context as androidx.activity.ComponentActivity
     val viewModel: RepositoryViewModel = viewModel(viewModelStoreOwner = activity)
+    val markdownState by viewModel.markdownState.collectAsState()
     var files by remember { mutableStateOf(viewModel.getDownloadedFiles()) }
     var deleteConfirmPath by remember { mutableStateOf<String?>(null) }
     var batchDeleteTargets by remember { mutableStateOf<List<String>?>(null) }
@@ -181,6 +184,11 @@ fun RepositoryDownloads(
             }
         }
     }
+
+    RepositoryMarkdownReader(
+        markdownState = markdownState,
+        onDismiss = { viewModel.clearMarkdown() }
+    )
 
     // 单个删除确认
     deleteConfirmPath?.let { path ->
@@ -316,7 +324,7 @@ private fun DownloadedFileRow(
                 overflow = TextOverflow.Ellipsis
             )
             Text(
-                text = "${formatSize(file.size)} · ${file.path}",
+                text = "${formatSize(file.size)} · ${RepositoryManager.formatDisplayPath(file.path)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryDownloads.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryDownloads.kt
@@ -2,6 +2,7 @@ package com.ahu.ahutong.ui.screen.main
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -59,6 +60,7 @@ import com.kyant.monet.withNight
 fun RepositoryDownloads(
     navController: NavHostController
 ) {
+    val isDark = isSystemInDarkTheme()
     val context = LocalContext.current
     val activity = context as androidx.activity.ComponentActivity
     val viewModel: RepositoryViewModel = viewModel(viewModelStoreOwner = activity)
@@ -68,6 +70,11 @@ fun RepositoryDownloads(
     var batchDeleteTargets by remember { mutableStateOf<List<String>?>(null) }
     var isManaging by remember { mutableStateOf(false) }
     var selectedPaths by remember { mutableStateOf(setOf<String>()) }
+    val secondaryTextColor = if (isDark) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
     fun refreshFiles() {
         files = viewModel.getDownloadedFiles()
@@ -116,10 +123,10 @@ fun RepositoryDownloads(
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text("暂无下载文件", style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        color = secondaryTextColor)
                     Spacer(modifier = Modifier.height(8.dp))
                     Text("浏览学习资料时可下载文件", style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        color = secondaryTextColor)
                 }
             }
         } else {
@@ -127,7 +134,7 @@ fun RepositoryDownloads(
                 modifier = Modifier
                     .fillMaxSize()
                     .weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 items(files, key = { it.path }) { file ->
                     val isSelected = file.path in selectedPaths
@@ -177,7 +184,7 @@ fun RepositoryDownloads(
                         Text(
                             "删除选中 (${selectedPaths.size})",
                             color = if (selectedPaths.isNotEmpty()) Color(0xFFFF5252)
-                                    else MaterialTheme.colorScheme.onSurfaceVariant
+                                    else secondaryTextColor
                         )
                     }
                 }
@@ -267,16 +274,39 @@ private fun DownloadedFileRow(
     onClick: () -> Unit,
     onDelete: () -> Unit
 ) {
+    val isDark = isSystemInDarkTheme()
     val typeLabel = RepositoryViewModel.getFileTypeIcon(file.name)
+    val fileAccentColor = when (typeLabel) {
+        "PDF" -> Color(0xFFE53935)
+        "DOC" -> Color(0xFF1565C0)
+        "PPT" -> Color(0xFFE65100)
+        "XLS" -> Color(0xFF2E7D32)
+        else -> Color(0xFF757575)
+    }
+    val fileBadgeColor = if (isDark) {
+        fileAccentColor.copy(alpha = 0.88f)
+    } else {
+        fileAccentColor.copy(alpha = 0.14f)
+    }
+    val fileBadgeTextColor = if (isDark) Color.White else fileAccentColor
+    val secondaryTextColor = if (isDark) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val uncheckedCheckboxColor = if (isDark) {
+        Color.White.copy(alpha = 0.88f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp)
-            .clip(SmoothRoundedCornerShape(16.dp))
-            .background(100.n1 withNight 30.n1)
+            .padding(horizontal = 18.dp)
+            .clip(RoundedCornerShape(24.dp))
             .clickable { onClick() }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 6.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // 管理模式：复选框
@@ -284,7 +314,7 @@ private fun DownloadedFileRow(
             Icon(
                 imageVector = if (isSelected) Icons.Filled.CheckBox else Icons.Outlined.CheckBoxOutlineBlank,
                 contentDescription = if (isSelected) "已选择" else "未选择",
-                tint = if (isSelected) 90.a1 withNight 90.a1 else MaterialTheme.colorScheme.onSurfaceVariant,
+                tint = if (isSelected) 90.a1 withNight 90.a1 else uncheckedCheckboxColor,
                 modifier = Modifier.size(24.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -293,40 +323,32 @@ private fun DownloadedFileRow(
         // 类型标签
         Box(
             modifier = Modifier
-                .size(32.dp)
-                .clip(RoundedCornerShape(6.dp))
-                .background(
-                    when (typeLabel) {
-                        "PDF" -> Color(0xFFE53935)
-                        "DOC" -> Color(0xFF1565C0)
-                        "PPT" -> Color(0xFFE65100)
-                        "XLS" -> Color(0xFF2E7D32)
-                        else -> Color(0xFF757575)
-                    }
-                ),
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(fileBadgeColor),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = typeLabel,
                 style = MaterialTheme.typography.labelSmall,
-                color = Color.White,
+                color = fileBadgeTextColor,
                 fontWeight = FontWeight.Bold
             )
         }
 
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(18.dp))
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = file.name,
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.titleMedium,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = "${formatSize(file.size)} · ${RepositoryManager.formatDisplayPath(file.path)}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyMedium,
+                color = secondaryTextColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryRoutes.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositoryRoutes.kt
@@ -1,0 +1,20 @@
+package com.ahu.ahutong.ui.screen.main
+
+import android.net.Uri
+import androidx.navigation.NavHostController
+
+const val REPOSITORY_ROUTE = "repository"
+const val REPOSITORY_PATH_ARG = "path"
+const val REPOSITORY_DIRECTORY_ROUTE = "repository_dir?path={path}"
+
+fun repositoryRoute(path: String): String {
+    return if (path.isBlank()) {
+        REPOSITORY_ROUTE
+    } else {
+        "repository_dir?path=${Uri.encode(path)}"
+    }
+}
+
+fun NavHostController.navigateRepository(path: String) {
+    navigate(repositoryRoute(path))
+}

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositorySettings.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositorySettings.kt
@@ -1,0 +1,145 @@
+package com.ahu.ahutong.ui.screen.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.ahu.ahutong.data.repository.RepositoryAccelerationSource
+import com.ahu.ahutong.data.repository.RepositoryManager
+import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
+import com.ahu.ahutong.ui.state.PreferencesViewModel
+import com.kyant.monet.a1
+import com.kyant.monet.n1
+import com.kyant.monet.withNight
+
+@Composable
+fun RepositorySettings(
+    navController: NavHostController,
+    preferencesViewModel: PreferencesViewModel = hiltViewModel()
+) {
+    val selectedSourceId by preferencesViewModel.repositoryAccelerationSource.collectAsState()
+    val cardColor = 100.n1 withNight 20.n1
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .background(96.n1 withNight 10.n1)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "返回"
+                )
+            }
+            Text(
+                text = "学习资料设置",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "GitHub 加速源",
+                modifier = Modifier.padding(horizontal = 8.dp),
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(SmoothRoundedCornerShape(24.dp))
+                    .background(cardColor),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                RepositoryManager.accelerationSources.forEach { source ->
+                    RepositoryAccelerationSourceRow(
+                        source = source,
+                        selected = source.id == selectedSourceId,
+                        onClick = {
+                            preferencesViewModel.setRepositoryAccelerationSource(source.id)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RepositoryAccelerationSourceRow(
+    source: RepositoryAccelerationSource,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .background(if (selected) 92.a1 withNight 32.a1 else Color.Transparent)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = source.name,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = source.description,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        if (selected) {
+            Spacer(modifier = Modifier.width(12.dp))
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = "已选择",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositorySettings.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/RepositorySettings.kt
@@ -2,6 +2,7 @@ package com.ahu.ahutong.ui.screen.main
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -113,6 +114,13 @@ private fun RepositoryAccelerationSourceRow(
     selected: Boolean,
     onClick: () -> Unit
 ) {
+    val isDark = isSystemInDarkTheme()
+    val descriptionColor = if (isDark) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -128,7 +136,7 @@ private fun RepositoryAccelerationSourceRow(
             )
             Text(
                 text = source.description,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = descriptionColor,
                 style = MaterialTheme.typography.bodyMedium
             )
         }

--- a/app/src/main/java/com/ahu/ahutong/ui/state/PreferencesViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/PreferencesViewModel.kt
@@ -32,6 +32,10 @@ class PreferencesViewModel @Inject constructor(private val preferencesManager: P
     val courseReminderLiveCountdownEnabled: StateFlow<Boolean> =
         _courseReminderLiveCountdownEnabled.asStateFlow()
 
+    private val _repositoryAccelerationSource = MutableStateFlow("jsdelivr")
+    val repositoryAccelerationSource: StateFlow<String> =
+        _repositoryAccelerationSource.asStateFlow()
+
     init {
         viewModelScope.launch {
             preferencesManager.themeColor.collect {
@@ -61,6 +65,11 @@ class PreferencesViewModel @Inject constructor(private val preferencesManager: P
         viewModelScope.launch {
             preferencesManager.courseReminderLiveCountdownEnabled.collect {
                 _courseReminderLiveCountdownEnabled.value = it
+            }
+        }
+        viewModelScope.launch {
+            preferencesManager.repositoryAccelerationSource.collect {
+                _repositoryAccelerationSource.value = it
             }
         }
     }
@@ -98,6 +107,12 @@ class PreferencesViewModel @Inject constructor(private val preferencesManager: P
     fun setThemeColor(value: String?) {
         viewModelScope.launch {
             preferencesManager.setThemeColor(value)
+        }
+    }
+
+    fun setRepositoryAccelerationSource(value: String) {
+        viewModelScope.launch {
+            preferencesManager.setRepositoryAccelerationSource(value)
         }
     }
 }

--- a/app/src/main/java/com/ahu/ahutong/ui/state/RepositoryViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/RepositoryViewModel.kt
@@ -12,7 +12,8 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.ahu.ahutong.data.repository.DownloadedFile
 import com.ahu.ahutong.data.repository.GitHubContentItem
-import com.ahu.ahutong.data.repository.RepoConfig
+import com.ahu.ahutong.data.repository.RepositoryDirectorySummary
+import com.ahu.ahutong.data.repository.RepositoryMarkdownDocument
 import com.ahu.ahutong.data.repository.RepositoryManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,211 +22,334 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 data class RepositoryUiState(
-    val selectedRepoId: String? = null,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
-    val pendingPath: String? = null,
+    val isLoaded: Boolean = false,
     val items: List<GitHubContentItem> = emptyList(),
     val currentPath: String = "",
-    val pathStack: List<String> = emptyList(),
     val error: String? = null,
     val isShowingCachedContents: Boolean = false,
     val cacheUpdatedAt: Long? = null,
+    val directorySummaries: Map<String, RepositoryDirectorySummary> = emptyMap()
+)
+
+data class RepositorySharedUiState(
     val downloadedPaths: Set<String> = emptySet(),
     val downloadProgress: Map<String, Float> = emptyMap(),
-    val downloadingPaths: Set<String> = emptySet(),
+    val downloadingPath: String? = null,
+    val isCacheWarming: Boolean = false,
+    val cacheWarmUpCount: Int = 0
+)
+
+data class RepositoryScrollPosition(
+    val index: Int = 0,
+    val offset: Int = 0
+)
+
+data class RepositoryMarkdownUiState(
+    val isLoading: Boolean = false,
+    val document: RepositoryMarkdownDocument? = null,
+    val error: String? = null
 )
 
 class RepositoryViewModel(application: Application) : AndroidViewModel(application) {
     private val context: Context get() = getApplication()
     private var loadRequestId = 0
+    private val pathRequestIds = mutableMapOf<String, Int>()
+    private val scrollPositions = mutableMapOf<String, RepositoryScrollPosition>()
+    private var hasStartedWarmUp = false
 
-    private val _uiState = MutableStateFlow(RepositoryUiState())
-    val uiState: StateFlow<RepositoryUiState> = _uiState.asStateFlow()
+    private val _directoryStates = MutableStateFlow<Map<String, RepositoryUiState>>(emptyMap())
+    val directoryStates: StateFlow<Map<String, RepositoryUiState>> = _directoryStates.asStateFlow()
 
-    fun selectRepo(repoId: String) {
-        val state = _uiState.value
-        _uiState.value = state.copy(
-            selectedRepoId = repoId,
-            items = emptyList(),
-            currentPath = "",
-            pathStack = emptyList(),
-            pendingPath = null,
-            error = null
+    private val _sharedState = MutableStateFlow(
+        RepositorySharedUiState(downloadedPaths = refreshDownloadedSet())
+    )
+    val sharedState: StateFlow<RepositorySharedUiState> = _sharedState.asStateFlow()
+
+    private val _markdownState = MutableStateFlow(RepositoryMarkdownUiState())
+    val markdownState: StateFlow<RepositoryMarkdownUiState> = _markdownState.asStateFlow()
+
+    fun getInitialDirectoryState(path: String): RepositoryUiState {
+        return _directoryStates.value[path] ?: cachedDirectoryState(path) ?: RepositoryUiState(
+            currentPath = path,
+            isLoading = true
         )
-        loadContents()
     }
 
-    fun resetToRepoSelector() {
-        loadRequestId++
-        _uiState.value = RepositoryUiState()
+    fun getDirectoryState(path: String): RepositoryUiState {
+        return _directoryStates.value[path] ?: cachedDirectoryState(path) ?: RepositoryUiState(
+            currentPath = path,
+            isLoading = true
+        )
     }
 
-    fun loadContents(
-        path: String = "",
-        forceRefresh: Boolean = false,
-        targetPathStack: List<String>? = null
-    ) {
-        val repoId = _uiState.value.selectedRepoId ?: return
+    fun getSharedState(): RepositorySharedUiState = _sharedState.value
+
+    fun ensureLoaded(path: String) {
+        val state = _directoryStates.value[path]
+        if (state == null || !state.isLoaded && state.error == null) {
+            loadContents(path)
+        }
+    }
+
+    fun loadContents(path: String = "", forceRefresh: Boolean = false) {
         val requestId = ++loadRequestId
-        val startState = _uiState.value
-        val cached = if (forceRefresh) null else RepositoryManager.getCachedContents(repoId, path)
-        val isSameDisplayedPath = startState.currentPath == path
-        val hasDisplayedItems = startState.items.isNotEmpty()
-        val nextPathStack = targetPathStack ?: startState.pathStack
+        pathRequestIds[path] = requestId
+        val cached = if (forceRefresh) null else RepositoryManager.getCachedContents(path)
+        val startState = _directoryStates.value[path] ?: cachedDirectoryState(path)
 
         if (cached != null) {
-            _uiState.value = startState.copy(
-                isLoading = false,
-                isRefreshing = true,
-                pendingPath = null,
-                items = sortDisplayItems(cached.items),
-                currentPath = path,
-                pathStack = nextPathStack,
-                error = null,
-                isShowingCachedContents = true,
-                cacheUpdatedAt = cached.updateTime.takeIf { it > 0L },
-                downloadedPaths = refreshDownloadedSet()
-            )
-        } else {
-            _uiState.value = startState.copy(
-                isLoading = !hasDisplayedItems,
-                isRefreshing = hasDisplayedItems,
-                pendingPath = path.takeIf { !isSameDisplayedPath },
+            setDirectoryState(path, directoryStateFromCache(path, cached.items, cached.updateTime))
+            return
+        }
+
+        setDirectoryState(
+            path,
+            (startState ?: RepositoryUiState(currentPath = path)).copy(
+                isLoading = startState?.items.isNullOrEmpty(),
+                isRefreshing = !startState?.items.isNullOrEmpty(),
+                isLoaded = startState?.isLoaded == true,
                 error = null
             )
-        }
+        )
 
         viewModelScope.launch {
             try {
-                val items = RepositoryManager.getContents(repoId, path)
-                val downloads = refreshDownloadedSet()
-                if (requestId != loadRequestId) return@launch
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    isRefreshing = false,
-                    pendingPath = null,
-                    items = sortDisplayItems(items),
-                    currentPath = path,
-                    pathStack = nextPathStack,
-                    downloadedPaths = downloads,
-                    isShowingCachedContents = false,
-                    cacheUpdatedAt = System.currentTimeMillis(),
-                    error = null
+                val items = RepositoryManager.getContents(path, forceRefresh = forceRefresh)
+                if (pathRequestIds[path] != requestId) return@launch
+                val sortedItems = sortDisplayItems(path, items)
+                setDirectoryState(
+                    path,
+                    RepositoryUiState(
+                        isLoading = false,
+                        isRefreshing = false,
+                        isLoaded = true,
+                        items = sortedItems,
+                        currentPath = path,
+                        isShowingCachedContents = false,
+                        cacheUpdatedAt = System.currentTimeMillis(),
+                        directorySummaries = RepositoryManager.getDirectorySummaries(sortedItems)
+                    )
+                )
+                _sharedState.value = _sharedState.value.copy(
+                    downloadedPaths = refreshDownloadedSet()
                 )
             } catch (e: Exception) {
-                if (requestId != loadRequestId) return@launch
-                val currentState = _uiState.value
-                val canKeepDisplayedItems = currentState.items.isNotEmpty()
-                if (canKeepDisplayedItems) {
-                    val failedNavigation = !isSameDisplayedPath && cached == null
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        pendingPath = null,
-                        isShowingCachedContents = if (failedNavigation) currentState.isShowingCachedContents else true,
-                        cacheUpdatedAt = cached?.updateTime?.takeIf { it > 0L } ?: currentState.cacheUpdatedAt,
-                        error = if (failedNavigation) "无法进入 ${path.substringAfterLast('/')}，仍停留在当前目录" else null
+                if (pathRequestIds[path] != requestId) return@launch
+                val fallback = RepositoryManager.getCachedContents(path)
+                if (fallback != null) {
+                    setDirectoryState(
+                        path,
+                        directoryStateFromCache(path, fallback.items, fallback.updateTime).copy(
+                            error = null
+                        )
                     )
                 } else {
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        pendingPath = null,
-                        error = "加载失败: ${e.message}"
+                    setDirectoryState(
+                        path,
+                        (_directoryStates.value[path] ?: RepositoryUiState(currentPath = path)).copy(
+                            isLoading = false,
+                            isRefreshing = false,
+                            error = "加载失败: ${e.message}"
+                        )
                     )
                 }
             }
         }
     }
 
-    fun refreshCurrentDirectory() {
-        loadContents(_uiState.value.currentPath, forceRefresh = true)
-    }
-
-    fun enterDirectory(item: GitHubContentItem) {
-        if (item.type != "dir") return
-        val state = _uiState.value
-        if (state.pendingPath != null) return
-        val newPath = item.path
-        if (newPath == state.currentPath) return
-        loadContents(newPath, targetPathStack = state.pathStack + state.currentPath)
-    }
-
-    fun goBack(): Boolean {
-        val state = _uiState.value
-        if (state.pendingPath != null) {
-            loadRequestId++
-            _uiState.value = state.copy(
-                isLoading = false, isRefreshing = false, pendingPath = null, error = null
-            )
-            return true
+    fun warmUpAllContentCaches(forceRefresh: Boolean = false) {
+        if (hasStartedWarmUp && !forceRefresh) return
+        hasStartedWarmUp = true
+        _sharedState.value = _sharedState.value.copy(
+            isCacheWarming = true,
+            cacheWarmUpCount = 0
+        )
+        viewModelScope.launch {
+            runCatching {
+                RepositoryManager.warmUpAllContentCaches(
+                    forceRefresh = forceRefresh,
+                    onProgress = { fetchedCount ->
+                        _sharedState.value = _sharedState.value.copy(
+                            isCacheWarming = true,
+                            cacheWarmUpCount = fetchedCount
+                        )
+                    }
+                )
+            }.onSuccess { updateTime ->
+                val states = _directoryStates.value.toMutableMap()
+                states.keys.toList().forEach { path ->
+                    RepositoryManager.getCachedContents(path)?.let { cached ->
+                        states[path] = directoryStateFromCache(path, cached.items, updateTime)
+                    }
+                }
+                _directoryStates.value = states
+                _sharedState.value = _sharedState.value.copy(
+                    isCacheWarming = false,
+                    cacheWarmUpCount = 0
+                )
+            }.onFailure {
+                _sharedState.value = _sharedState.value.copy(
+                    isCacheWarming = false,
+                    cacheWarmUpCount = 0
+                )
+            }
         }
-        val stack = state.pathStack
-        if (stack.isEmpty()) return false
-        val parentPath = stack.last()
-        loadContents(parentPath, targetPathStack = stack.dropLast(1))
-        return true
+    }
+
+    fun refreshDirectory(path: String) {
+        loadContents(path, forceRefresh = true)
+    }
+
+    fun saveScrollPosition(path: String, index: Int, offset: Int) {
+        scrollPositions[path] = RepositoryScrollPosition(index, offset)
+    }
+
+    fun getScrollPosition(path: String): RepositoryScrollPosition {
+        return scrollPositions[path] ?: RepositoryScrollPosition()
     }
 
     fun downloadFile(item: GitHubContentItem) {
-        val repoId = _uiState.value.selectedRepoId ?: return
         viewModelScope.launch {
             val path = item.path
-            _uiState.value = _uiState.value.copy(
-                downloadingPaths = _uiState.value.downloadingPaths + path,
-                downloadProgress = _uiState.value.downloadProgress + (path to 0f)
+            _sharedState.value = _sharedState.value.copy(
+                downloadingPath = path,
+                downloadProgress = _sharedState.value.downloadProgress + (path to 0f)
             )
             try {
-                val file = RepositoryManager.downloadFile(repoId, path, context) { progress ->
-                    _uiState.value = _uiState.value.copy(
-                        downloadProgress = _uiState.value.downloadProgress + (path to progress)
+                val file = RepositoryManager.downloadFile(path, context) { progress ->
+                    _sharedState.value = _sharedState.value.copy(
+                        downloadProgress = _sharedState.value.downloadProgress + (path to progress)
                     )
                 }
                 if (file != null) {
                     val downloads = refreshDownloadedSet()
-                    _uiState.value = _uiState.value.copy(
-                        downloadingPaths = _uiState.value.downloadingPaths - path,
+                    _sharedState.value = _sharedState.value.copy(
+                        downloadingPath = null,
                         downloadedPaths = downloads,
-                        downloadProgress = _uiState.value.downloadProgress - path
+                        downloadProgress = _sharedState.value.downloadProgress - path
                     )
                     Toast.makeText(context, "下载完成: ${item.name}", Toast.LENGTH_SHORT).show()
                 } else {
-                    _uiState.value = _uiState.value.copy(
-                        downloadingPaths = _uiState.value.downloadingPaths - path,
-                        downloadProgress = _uiState.value.downloadProgress - path,
-                        error = "下载失败: ${item.name}"
+                    _sharedState.value = _sharedState.value.copy(
+                        downloadingPath = null,
+                        downloadProgress = _sharedState.value.downloadProgress - path
                     )
+                    setPathError(item.parentPath(), buildDownloadErrorMessage(item.name))
                 }
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    downloadingPaths = _uiState.value.downloadingPaths - path,
-                    downloadProgress = _uiState.value.downloadProgress - path,
-                    error = "下载失败: ${e.message}"
+                _sharedState.value = _sharedState.value.copy(
+                    downloadingPath = null,
+                    downloadProgress = _sharedState.value.downloadProgress - path
                 )
+                setPathError(item.parentPath(), buildDownloadErrorMessage(e.message))
             }
         }
     }
 
     fun openFile(item: GitHubContentItem) {
-        val file = RepositoryManager.getLocalFile(item.path, context)
-        if (file != null) openWithSystemViewer(file)
-        else Toast.makeText(context, "文件不存在，请先下载", Toast.LENGTH_SHORT).show()
+        if (isMarkdownFile(item.name)) {
+            loadMarkdown(item.path)
+            return
+        }
+        val file = RepositoryManager.getDownloadedFile(item.path, context)
+        if (file != null) {
+            openDownloadedFile(file)
+        } else {
+            Toast.makeText(context, "文件不存在，请先下载", Toast.LENGTH_SHORT).show()
+        }
     }
 
     fun deleteFile(path: String) {
         RepositoryManager.deleteFile(path, context)
-        _uiState.value = _uiState.value.copy(downloadedPaths = refreshDownloadedSet())
+        val downloads = refreshDownloadedSet()
+        _sharedState.value = _sharedState.value.copy(downloadedPaths = downloads)
     }
 
-    fun getDownloadedFiles(): List<DownloadedFile> = RepositoryManager.getDownloadedFiles(context)
+    fun getRawUrl(path: String): String = RepositoryManager.getRawUrl(path)
 
-    fun getLocalFile(path: String): File? = RepositoryManager.getLocalFile(path, context)
+    fun getGitHubUrl(path: String): String = RepositoryManager.getGitHubUrl(path)
+
+    fun shouldShowUnsupportedDirectoryMessage(path: String): Boolean {
+        return RepositoryManager.shouldShowUnsupportedDirectoryMessage(path)
+    }
+
+    fun loadMarkdown(path: String) {
+        _markdownState.value = RepositoryMarkdownUiState(isLoading = true)
+        viewModelScope.launch {
+            runCatching {
+                RepositoryManager.getMarkdownDocument(path)
+            }.onSuccess { document ->
+                _markdownState.value = RepositoryMarkdownUiState(document = document)
+            }.onFailure { e ->
+                _markdownState.value = RepositoryMarkdownUiState(
+                    error = "Markdown 加载失败: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun clearMarkdown() {
+        _markdownState.value = RepositoryMarkdownUiState()
+    }
+
+    private fun loadDownloadedMarkdown(file: DownloadedFile) {
+        _markdownState.value = RepositoryMarkdownUiState(isLoading = true)
+        viewModelScope.launch {
+            runCatching {
+                val uri = file.uri?.let { Uri.parse(it) }
+                val content = if (uri != null) {
+                    context.contentResolver.openInputStream(uri)?.bufferedReader()?.use {
+                        it.readText()
+                    } ?: throw IllegalStateException("无法读取本地 Markdown")
+                } else {
+                    val localFile = File(file.localPath)
+                    if (!localFile.exists()) {
+                        deleteFile(file.path)
+                        throw IllegalStateException("文件已被删除")
+                    }
+                    localFile.readText()
+                }
+                RepositoryMarkdownDocument(
+                    title = file.name,
+                    path = file.path,
+                    content = content
+                )
+            }.onSuccess { document ->
+                _markdownState.value = RepositoryMarkdownUiState(document = document)
+            }.onFailure { e ->
+                _markdownState.value = RepositoryMarkdownUiState(
+                    error = "Markdown 加载失败: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun getDownloadedFiles(): List<DownloadedFile> {
+        return RepositoryManager.getDownloadedFiles(context)
+    }
+
+    fun getLocalFile(path: String): File? {
+        return RepositoryManager.getLocalFile(path, context)
+    }
 
     fun openDownloadedFile(file: DownloadedFile) {
+        if (isMarkdownFile(file.name)) {
+            loadDownloadedMarkdown(file)
+            return
+        }
+
+        val uri = file.uri?.let { Uri.parse(it) }
+        if (uri != null) {
+            openUriWithSystemViewer(uri, file.name)
+            return
+        }
+
         val localFile = File(file.localPath)
-        if (localFile.exists()) openWithSystemViewer(localFile)
-        else {
+        if (localFile.exists()) {
+            openWithSystemViewer(localFile)
+        } else {
             deleteFile(file.path)
             Toast.makeText(context, "文件已被删除", Toast.LENGTH_SHORT).show()
         }
@@ -233,11 +357,32 @@ class RepositoryViewModel(application: Application) : AndroidViewModel(applicati
 
     private fun openWithSystemViewer(file: File) {
         try {
-            if (!file.exists()) { Toast.makeText(context, "文件不存在", Toast.LENGTH_SHORT).show(); return }
-            val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+            if (!file.exists()) {
+                Toast.makeText(context, "文件不存在", Toast.LENGTH_SHORT).show()
+                return
+            }
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                file
+            )
             val mimeType = getMimeType(file.name)
             if (!startFileViewer(uri, file.name, mimeType) &&
                 (mimeType == "*/*" || !startFileViewer(uri, file.name, "*/*"))
+            ) {
+                Toast.makeText(context, "没有找到可打开此文件的软件", Toast.LENGTH_SHORT).show()
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("RepoViewer", "打开失败: ${e.message}", e)
+            Toast.makeText(context, "打开失败: ${e.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun openUriWithSystemViewer(uri: Uri, fileName: String) {
+        try {
+            val mimeType = getMimeType(fileName)
+            if (!startFileViewer(uri, fileName, mimeType) &&
+                (mimeType == "*/*" || !startFileViewer(uri, fileName, "*/*"))
             ) {
                 Toast.makeText(context, "没有找到可打开此文件的软件", Toast.LENGTH_SHORT).show()
             }
@@ -260,22 +405,88 @@ class RepositoryViewModel(application: Application) : AndroidViewModel(applicati
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
-        return try { context.startActivity(chooserIntent); true } catch (e: ActivityNotFoundException) { false }
+
+        return try {
+            context.startActivity(chooserIntent)
+            true
+        } catch (e: ActivityNotFoundException) {
+            false
+        }
     }
 
-    fun clearError() { _uiState.value = _uiState.value.copy(error = null) }
+    fun clearError(path: String) {
+        _directoryStates.value[path]?.let { state ->
+            setDirectoryState(path, state.copy(error = null))
+        }
+    }
+
+    private fun cachedDirectoryState(path: String): RepositoryUiState? {
+        val cached = RepositoryManager.getCachedContents(path) ?: return null
+        return directoryStateFromCache(path, cached.items, cached.updateTime)
+    }
+
+    private fun directoryStateFromCache(
+        path: String,
+        items: List<GitHubContentItem>,
+        updateTime: Long
+    ): RepositoryUiState {
+        val sortedItems = sortDisplayItems(path, items)
+        return RepositoryUiState(
+            isLoading = false,
+            isRefreshing = false,
+            isLoaded = true,
+            items = sortedItems,
+            currentPath = path,
+            isShowingCachedContents = true,
+            cacheUpdatedAt = updateTime.takeIf { it > 0L },
+            directorySummaries = RepositoryManager.getDirectorySummaries(sortedItems)
+        )
+    }
+
+    private fun setDirectoryState(path: String, state: RepositoryUiState) {
+        _directoryStates.value = _directoryStates.value + (path to state.copy(currentPath = path))
+    }
+
+    private fun setPathError(path: String, message: String) {
+        setDirectoryState(
+            path,
+            (_directoryStates.value[path] ?: cachedDirectoryState(path) ?: RepositoryUiState(
+                currentPath = path
+            )).copy(error = message)
+        )
+    }
+
+    private fun GitHubContentItem.parentPath(): String = path.substringBeforeLast('/', "")
 
     private fun refreshDownloadedSet(): Set<String> {
-        return RepositoryManager.getDownloadedFiles(context).map { it.path }.toSet()
+        val files = RepositoryManager.getDownloadedFiles(context)
+        return files.map { it.path }.toSet()
     }
 
-    private fun sortDisplayItems(items: List<GitHubContentItem>): List<GitHubContentItem> {
+    private fun buildDownloadErrorMessage(detail: String?): String {
+        val suffix = "，可前往学习资料设置更换下载源后重试"
+        val normalizedDetail = detail?.takeIf { it.isNotBlank() } ?: "未知原因"
+        return "下载失败: $normalizedDetail$suffix"
+    }
+
+    private fun sortDisplayItems(path: String, items: List<GitHubContentItem>): List<GitHubContentItem> {
+        if (path.isBlank()) {
+            return items.sortedWith(
+                compareBy<GitHubContentItem> { if (it.type == "dir") 0 else 1 }
+                    .thenBy { RepositoryManager.getRepositoryOrder(it.path) }
+                    .thenBy { it.name.lowercase() }
+            )
+        }
         val dirs = items.filter { it.type == "dir" }.sortedBy { it.name.lowercase() }
         val files = items.filter { it.type == "file" }.sortedBy { it.name.lowercase() }
         return dirs + files
     }
 
     companion object {
+        fun isMarkdownFile(name: String): Boolean {
+            return name.lowercase().endsWith(".md")
+        }
+
         fun getMimeType(fileName: String): String {
             val lower = fileName.lowercase()
             return when {

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,6 @@
     <external-files-path name="external_files" path="." />
     <external-files-path name="ext_repo" path="repository/" />
     <files-path name="repo_files" path="repository/" />
+    <external-path name="public_downloads" path="Download/" />
+    <external-path name="public_repository" path="Download/ahutong/" />
 </paths>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ zxingAndroidEmbeddedVersion = "4.3.0"
 adsMobileSdkVersion = "0.18.0-beta01"
 kyant0Backdrop = "1.0.0"
 kyant0Capsule = "2.1.1"
+markwon = "4.6.2"
 
 [libraries]
 conscrypt = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
@@ -58,6 +59,7 @@ ads-mobile-sdk = { group = "com.google.android.libraries.ads.mobile.sdk", name =
 crashreport = { module = "com.tencent.bugly:crashreport", version.ref = "crashreport" }
 kyant0-backdrop = { module = "io.github.kyant0:backdrop", version.ref = "kyant0Backdrop" }
 kyant0-capsule = { module = "io.github.kyant0:capsule", version.ref = "kyant0Capsule" }
+markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 说明

### 改动内容

- 重构学习资料多级目录导航，统一系统返回手势与页面返回按钮的逐级返回行为
- 为学习资料模块补充独立路由与设置页，支持切换 GitHub 加速源
- 重构目录索引与本地缓存逻辑，优化首屏预热与后续秒开体验
- 修复目录路径展示异常，面包屑路径改为仅显示文件夹名，并支持横向滚动及自动滚动到末尾
- 修复浅色模式下学习资料页面布局偏移问题，列表样式调整为更接近文件管理器的一体化布局
- 统一加载反馈，初次进入时展示居中进度提示，并按已获取文件数更新
- 优化下载交互：
  - 默认下载到 `Download/ahutong`
  - 调整下载图标样式与位置
  - 下载完成后将已下载标识移动到文件名后方
  - 下载失败时增加“可前往学习资料设置更换下载源后重试”的提示
- 支持应用内直接打开并渲染 Markdown 文件
- 合并学校资料源调整，补充石溪学院入口并按根目录顺序放在最后
- 补充空目录文案，对仅包含非文档格式文件的目录引导前往对应 GitHub 目录查看

### 验证方式

- 执行 `adb devices`，确认存在可用设备
- 执行 `.\gradlew.bat :app:compileDebugKotlin :app:assembleDebug`
- 在设备 `Redmi K70E` 上安装并启动 Debug 包验证页面加载、目录跳转与下载流程

### 影响范围

- 学习资料模块的路由、缓存、下载、LFS 处理、设置页与列表 UI
- AndroidManifest 与下载路径相关配置