### PR TITLE
接入了校园卡招商银行充值与网费充值能力

### DIFF
--- a/app/src/main/java/com/ahu/ahutong/data/api/AHUCookieJar.java
+++ b/app/src/main/java/com/ahu/ahutong/data/api/AHUCookieJar.java
@@ -10,6 +10,7 @@ import com.franmontiel.persistentcookiejar.cache.CookieCache;
 import com.franmontiel.persistentcookiejar.persistence.CookiePersistor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -138,5 +139,16 @@ public class AHUCookieJar implements ClearableCookieJar {
         cache.addAll(cookies);
         // 如果需要持久化（下次启动免登录），这里会自动保存
         persistor.saveAll(filterPersistentCookies(cookies));
+    }
+
+    @NonNull
+    synchronized public List<Cookie> getAllCookies() {
+        List<Cookie> cookies = new ArrayList<>();
+        for (Cookie cookie : cache) {
+            if (!isCookieExpired(cookie)) {
+                cookies.add(cookie);
+            }
+        }
+        return Collections.unmodifiableList(cookies);
     }
 }

--- a/app/src/main/java/com/ahu/ahutong/data/crawler/api/ycard/YcardApi.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/crawler/api/ycard/YcardApi.kt
@@ -18,6 +18,7 @@ import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -35,13 +36,35 @@ interface YcardApi {
         @Query("synAccessSource") synAccessSource: String = "h5",
     ): CardInfo
 
+    @GET("/charge/feeitem/toAppitem")
+    suspend fun enterFeeItem(
+        @Query("feeitemid") feeitemid: String,
+        @Query("appId") appId: String,
+        @Query("loginFrom") loginFrom: String = "h5",
+        @Query("synAccessSource") synAccessSource: String = "h5",
+        @Query("synjones-auth") synjonesAuth: String
+    ): Response<ResponseBody>
+
+    @Headers("Referer: https://ycard.ahu.edu.cn/charge-app/")
+    @GET("/charge/feeitem/singleFeeitem")
+    suspend fun getSingleFeeItem(
+        @Query("feeitemid") feeitemid: String
+    ): Response<ResponseBody>
+
     @POST("/charge/order/thirdOrder")
     suspend fun getOrderThirdData(@Body body: RequestBody): Response<ResponseBody>
 
-
+    @Headers(
+        "Referer: https://ycard.ahu.edu.cn/charge-app/",
+        "Origin: https://ycard.ahu.edu.cn"
+    )
     @POST("/charge/feeitem/getThirdData")
-    suspend fun getFeeItemThirdData(@Body body: RequestBody):Response<ResponseBody>
+    suspend fun getFeeItemThirdData(@Body body: RequestBody): Response<ResponseBody>
 
+    @Headers(
+        "Referer: https://ycard.ahu.edu.cn/charge-app/",
+        "Origin: https://ycard.ahu.edu.cn"
+    )
     @POST("/blade-pay/pay")
     suspend fun pay(
         @Body body: RequestBody

--- a/app/src/main/java/com/ahu/ahutong/data/crawler/manager/TokenManager.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/crawler/manager/TokenManager.kt
@@ -2,6 +2,7 @@ package com.ahu.ahutong.data.crawler.manager
 
 import android.util.Log
 import com.ahu.ahutong.data.crawler.api.ycard.YcardApi
+import okhttp3.Response
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -25,7 +26,8 @@ object TokenManager {
             CookieManager.cookieJar.logAllCookies()
 
             val loginResponse = YcardApi.API.login().execute()      //假设已经登陆过one.ahu.ehu.cn
-            val redirectUrl = loginResponse.raw().request.url.toString()
+            val redirectUrl = extractRedirectLocation(loginResponse)
+                ?: loginResponse.raw().request.url.toString()
 
             val regex = Regex("[?&]ticket=([^&]+)")
             val match = regex.find(redirectUrl)
@@ -68,6 +70,19 @@ object TokenManager {
         return withContext(Dispatchers.IO) {
             getToken()
         }
+    }
+
+    private fun extractRedirectLocation(response: retrofit2.Response<*>): String? {
+        var current: Response? = response.raw().priorResponse
+        while (current != null) {
+            current.header("Location")?.let { location ->
+                if ("ticket=" in location) {
+                    return location
+                }
+            }
+            current = current.priorResponse
+        }
+        return response.raw().header("Location")
     }
 
     fun clear(){

--- a/app/src/main/java/com/ahu/ahutong/data/dao/AHUCache.kt
+++ b/app/src/main/java/com/ahu/ahutong/data/dao/AHUCache.kt
@@ -462,6 +462,20 @@ object AHUCache {
         kv.putBoolean("businessAccepted",true)
     }
 
+    fun isCmbCardRechargePreferred(): Boolean {
+        userGetString("cmb_card_recharge_preferred")?.toBooleanStrictOrNull()?.let { return it }
+        val value = kv.getBoolean("cmb_card_recharge_preferred", false)
+        if (kv.containsKey("cmb_card_recharge_preferred")) {
+            userPutString("cmb_card_recharge_preferred", value.toString())
+        }
+        return value
+    }
+
+    fun setCmbCardRechargePreferred(preferred: Boolean) {
+        userPutString("cmb_card_recharge_preferred", preferred.toString())
+        kv.putBoolean("cmb_card_recharge_preferred", preferred)
+    }
+
     /**
      * 获取房间选择信息
      * @return RoomSelectionInfo?

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/Main.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/Main.kt
@@ -32,18 +32,20 @@ import com.ahu.ahutong.data.gray.GrayFeatures
 import com.ahu.ahutong.data.gray.GrayReleaseManager
 import com.ahu.ahutong.ui.screen.main.BathroomDeposit
 import com.ahu.ahutong.ui.screen.main.CardBalanceDeposit
+import com.ahu.ahutong.ui.screen.main.CmbCardRecharge
 import com.ahu.ahutong.ui.screen.main.ElectricityDeposit
 import com.ahu.ahutong.ui.screen.main.Exam
 import com.ahu.ahutong.ui.screen.main.FreeClassroom
 import com.ahu.ahutong.ui.screen.main.Grade
 import com.ahu.ahutong.ui.screen.main.Home
 import com.ahu.ahutong.ui.screen.main.LostFound
+import com.ahu.ahutong.ui.screen.main.NetworkRecharge
 import com.ahu.ahutong.ui.screen.main.PhoneBook
+import com.ahu.ahutong.ui.screen.main.Repository
+import com.ahu.ahutong.ui.screen.main.RepositoryDownloads
 import com.ahu.ahutong.ui.screen.main.Schedule
 import com.ahu.ahutong.ui.screen.main.SchoolCalendar
 import com.ahu.ahutong.ui.screen.main.Tools
-import com.ahu.ahutong.ui.screen.main.Repository
-import com.ahu.ahutong.ui.screen.main.RepositoryDownloads
 import com.ahu.ahutong.ui.screen.main.Weather
 import com.ahu.ahutong.ui.screen.settings.Contributors
 import com.ahu.ahutong.ui.screen.settings.Debug
@@ -216,11 +218,19 @@ fun Main(
             }
 
             animatedComposable("card_balance_deposit") {
-                CardBalanceDeposit()
+                CardBalanceDeposit(navController = navController)
             }
 
             animatedComposable("bathroom_deposit") {
                 BathroomDeposit()
+            }
+
+            animatedComposable("cmb_card_recharge") {
+                CmbCardRecharge()
+            }
+
+            animatedComposable("network_recharge") {
+                NetworkRecharge()
             }
 
             animatedComposable("debug") {

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/CardBalanceDeposit.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/CardBalanceDeposit.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -62,6 +63,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.data.mock.MockScenarioController
 import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
@@ -80,6 +82,7 @@ private const val ALIPAY_CAMPUS_CARD_FALLBACK_URL = "https://www.wmslz.com/s/M6K
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CardBalanceDeposit(
+    navController: NavController,
     viewModel: CardBalanceDepositViewModel = viewModel()
 ) {
 
@@ -91,6 +94,7 @@ fun CardBalanceDeposit(
     val paymentState by viewModel.paymentState.collectAsState()
 
     var showConfirmDialog by remember { mutableStateOf(false) }
+    var showCmbPreferenceDialog by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
@@ -234,13 +238,23 @@ fun CardBalanceDeposit(
 
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(start = 24.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
+            Text(
+                text = "招商银行充值点这里",
+                modifier = Modifier
+                    .clickable { showCmbPreferenceDialog = true }
+                    .padding(horizontal = 8.dp, vertical = 16.dp),
+                color = 30.n1 withNight 70.n1,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier
-                    .navigationBarsPadding()
-                    .padding(16.dp)
                     .clip(SmoothRoundedCornerShape(32.dp))
                     .background(
                         animateColorAsState(
@@ -436,6 +450,51 @@ fun CardBalanceDeposit(
                             .padding(8.dp),
                         color = 10.n1 withNight 90.n1
                     )
+                }
+            )
+        }
+
+        if (showCmbPreferenceDialog) {
+            AlertDialog(
+                containerColor = 100.n1 withNight 20.n1,
+                titleContentColor = 10.n1 withNight 90.n1,
+                textContentColor = 40.n1 withNight 60.n1,
+                onDismissRequest = { showCmbPreferenceDialog = false },
+                title = { Text("使用招商银行充值") },
+                text = { Text("是否以后都默认使用招商银行充值？") },
+                confirmButton = {
+                    Text(
+                        text = "以后都用",
+                        modifier = Modifier
+                            .clickable {
+                                AHUCache.setCmbCardRechargePreferred(true)
+                                showCmbPreferenceDialog = false
+                                navController.navigate("cmb_card_recharge")
+                            }
+                            .padding(8.dp),
+                        color = 10.n1 withNight 90.n1
+                    )
+                },
+                dismissButton = {
+                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Text(
+                            text = "取消",
+                            modifier = Modifier
+                                .clickable { showCmbPreferenceDialog = false }
+                                .padding(8.dp),
+                            color = 10.n1 withNight 90.n1
+                        )
+                        Text(
+                            text = "仅本次",
+                            modifier = Modifier
+                                .clickable {
+                                    showCmbPreferenceDialog = false
+                                    navController.navigate("cmb_card_recharge")
+                                }
+                                .padding(8.dp),
+                            color = 10.n1 withNight 90.n1
+                        )
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/CmbCardRecharge.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/CmbCardRecharge.kt
@@ -1,0 +1,373 @@
+package com.ahu.ahutong.ui.screen.main
+
+import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.unit.dp
+import com.ahu.ahutong.data.crawler.manager.CookieManager as YcardCookieManager
+import com.ahu.ahutong.data.crawler.manager.TokenManager
+import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
+import com.kyant.monet.n1
+import com.kyant.monet.withNight
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Cookie
+
+private const val CMB_RECHARGE_STYLE_SCRIPT = """
+(function(){
+  var styleId = 'ahutong-cmb-style';
+  if (document.getElementById(styleId)) return;
+  var style = document.createElement('style');
+  style.id = styleId;
+  style.textContent = [
+    'html,body,#app,#app-box{background:#eef2f5 !important;color:#1f2328 !important;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif !important;}',
+    'body{overscroll-behavior:none !important;-webkit-font-smoothing:antialiased !important;}',
+    '#app,#app-box,.page,.container,.main,.weui-tab__panel{max-width:720px;margin:0 auto !important;}',
+    '.weui-btn_primary,.weui-btn_warn,.weui-btn_default{border-radius:16px !important;box-shadow:none !important;}',
+    '.weui-btn_primary{background:#1e88e5 !important;border-color:#1e88e5 !important;}',
+    '.weui-btn_warn{background:#d94f4f !important;border-color:#d94f4f !important;}',
+    '.weui-btn_default{background:#ffffff !important;color:#1f2328 !important;border-color:#d0d7de !important;}',
+    '.weui-cells,.weui-panel,.card,.panel{border-radius:20px !important;overflow:hidden !important;background:#ffffff !important;}',
+    '.weui-cell{padding-top:14px !important;padding-bottom:14px !important;}',
+    '.van-cell,.van-field,.cell,.form-item,.pay-item{border-radius:16px !important;background:#ffffff !important;}',
+    '.van-button,.el-button,button{border-radius:16px !important;box-shadow:none !important;}',
+    '.van-button--primary,.el-button--primary,button[type=submit]{background:#1e88e5 !important;border-color:#1e88e5 !important;color:#ffffff !important;}',
+    '.van-field__label,.label,.title{color:#1f2328 !important;}',
+    '.van-field__control,input,textarea,select{color:#1f2328 !important;}',
+    '.van-cell-group,.form,.charge-box,.cashier-box{border-radius:20px !important;overflow:hidden !important;background:#ffffff !important;}',
+    'input,textarea,select{font-family:inherit !important;}',
+    'a{color:#1e88e5 !important;}'
+  ].join('');
+  document.head.appendChild(style);
+})();
+"""
+
+@Composable
+fun CmbCardRecharge() {
+    val context = LocalContext.current
+    var entryUrl by remember { mutableStateOf<String?>(null) }
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    var progress by remember { mutableIntStateOf(0) }
+    var tokenRequestVersion by remember { mutableIntStateOf(0) }
+    var loadRequestVersion by remember { mutableIntStateOf(0) }
+    var isLoading by remember { mutableStateOf(true) }
+    var canGoBack by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    BackHandler(enabled = canGoBack) {
+        webView?.goBack()
+    }
+
+    fun reloadEntry() {
+        progress = 0
+        isLoading = true
+        errorMessage = null
+        webView?.stopLoading()
+        loadRequestVersion += 1
+    }
+
+    LaunchedEffect(tokenRequestVersion) {
+        progress = 0
+        isLoading = true
+        errorMessage = null
+        entryUrl = null
+        canGoBack = false
+        val token = withContext(Dispatchers.IO) { TokenManager.awaitToken() }
+        if (token.isNullOrBlank()) {
+            errorMessage = "校园卡登录凭证暂未就绪，请稍后重试"
+            isLoading = false
+            return@LaunchedEffect
+        }
+        entryUrl = buildCmbRechargeEntryUrl(token)
+        loadRequestVersion += 1
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.stopLoading()
+            webView?.destroy()
+            webView = null
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+    ) {
+        Text(
+            text = "招商银行充值",
+            modifier = Modifier.padding(24.dp, 32.dp, 24.dp, 16.dp),
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        if (progress in 1..99) {
+            LinearProgressIndicator(
+                progress = { progress / 100f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+        }
+
+        errorMessage?.let { message ->
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .background(100.n1 withNight 20.n1, SmoothRoundedCornerShape(24.dp))
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = 10.n1 withNight 90.n1,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = "重试",
+                    modifier = Modifier.clickable {
+                        if (entryUrl == null) {
+                            errorMessage = null
+                            isLoading = true
+                            tokenRequestVersion += 1
+                        } else {
+                            reloadEntry()
+                        }
+                    },
+                    color = 30.n1 withNight 70.n1,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .background(100.n1 withNight 20.n1, SmoothRoundedCornerShape(24.dp))
+        ) {
+            entryUrl?.let { url ->
+                val requestVersion = loadRequestVersion
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { viewContext ->
+                        createCmbRechargeWebView(
+                            context = viewContext,
+                            onLoadingChanged = { isLoading = it },
+                            onProgressChanged = { progress = it },
+                            onNavigationChanged = { canGoBack = it },
+                            onMainFrameError = { error ->
+                                errorMessage = error
+                            },
+                            onExternalLink = { externalUrl ->
+                                openExternalLink(context, externalUrl)
+                            }
+                        ).also { created ->
+                            syncYcardCookiesToWebView(created)
+                            created.tag = requestVersion
+                            created.loadUrl(url)
+                            webView = created
+                        }
+                    },
+                    update = { currentView ->
+                        if (currentView.tag != requestVersion) {
+                            syncYcardCookiesToWebView(currentView)
+                            currentView.tag = requestVersion
+                            currentView.loadUrl(url)
+                        }
+                        webView = currentView
+                    }
+                )
+            }
+
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    color = 30.n1 withNight 70.n1
+                )
+            }
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun createCmbRechargeWebView(
+    context: android.content.Context,
+    onLoadingChanged: (Boolean) -> Unit,
+    onProgressChanged: (Int) -> Unit,
+    onNavigationChanged: (Boolean) -> Unit,
+    onMainFrameError: (String) -> Unit,
+    onExternalLink: (String) -> Unit
+): WebView {
+    return WebView(context).apply {
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.databaseEnabled = true
+        settings.loadsImagesAutomatically = true
+        settings.javaScriptCanOpenWindowsAutomatically = true
+        settings.useWideViewPort = true
+        settings.loadWithOverviewMode = true
+        settings.cacheMode = WebSettings.LOAD_DEFAULT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+        }
+        android.webkit.CookieManager.getInstance().setAcceptCookie(true)
+
+        webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                onProgressChanged(newProgress)
+                if (newProgress >= 100) {
+                    onLoadingChanged(false)
+                }
+            }
+        }
+
+        webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(
+                view: WebView?,
+                request: WebResourceRequest?
+            ): Boolean {
+                val targetUri = request?.url ?: return false
+                val scheme = targetUri.scheme?.lowercase().orEmpty()
+                if (scheme.isBlank()) return false
+                if (scheme != "http" && scheme != "https") {
+                    onExternalLink(targetUri.toString())
+                    return true
+                }
+                return if (isInternalCmbRechargeUrl(targetUri)) {
+                    false
+                } else {
+                    onExternalLink(targetUri.toString())
+                    true
+                }
+            }
+
+            override fun onPageStarted(view: WebView?, url: String?, favicon: android.graphics.Bitmap?) {
+                onLoadingChanged(true)
+                onNavigationChanged(view?.canGoBack() == true)
+                super.onPageStarted(view, url, favicon)
+            }
+
+            override fun onPageFinished(view: WebView?, url: String?) {
+                onLoadingChanged(false)
+                onNavigationChanged(view?.canGoBack() == true)
+                if (url?.contains("/cashier-mobile/charge") == true || url?.contains("/charge-app") == true) {
+                    view?.evaluateJavascript(CMB_RECHARGE_STYLE_SCRIPT, null)
+                }
+                super.onPageFinished(view, url)
+            }
+
+            override fun onReceivedError(
+                view: WebView?,
+                request: WebResourceRequest?,
+                error: WebResourceError?
+            ) {
+                if (request?.isForMainFrame == true) {
+                    onLoadingChanged(false)
+                    onMainFrameError(error?.description?.toString() ?: "页面加载失败，请稍后重试")
+                }
+                super.onReceivedError(view, request, error)
+            }
+        }
+    }
+}
+
+private fun buildCmbRechargeEntryUrl(token: String): String {
+    return Uri.Builder()
+        .scheme("https")
+        .authority("ycard.ahu.edu.cn")
+        .appendPath("berserker-base")
+        .appendPath("redirect")
+        .appendQueryParameter("appId", "253")
+        .appendQueryParameter("loginFrom", "h5")
+        .appendQueryParameter("synAccessSource", "h5")
+        .appendQueryParameter("synjones-auth", token)
+        .appendQueryParameter("type", "app")
+        .build()
+        .toString()
+}
+
+private fun isInternalCmbRechargeUrl(url: Uri): Boolean {
+    val host = url.host.orEmpty().lowercase()
+    return host == "ahu.edu.cn" || host.endsWith(".ahu.edu.cn")
+}
+
+private fun openExternalLink(context: android.content.Context, url: String) {
+    val targetUri = runCatching { Uri.parse(url) }.getOrNull()
+    if (targetUri == null) {
+        Toast.makeText(context, "无法打开外部链接", Toast.LENGTH_SHORT).show()
+        return
+    }
+
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, targetUri))
+    } catch (_: ActivityNotFoundException) {
+        Toast.makeText(context, "无法打开外部链接", Toast.LENGTH_SHORT).show()
+    }
+}
+
+private fun syncYcardCookiesToWebView(webView: WebView) {
+    val webCookieManager = android.webkit.CookieManager.getInstance()
+    YcardCookieManager.cookieJar.getAllCookies().forEach { cookie ->
+        val targetUrl = buildCookieTargetUrl(cookie)
+        val cookieValue = buildString {
+            append(cookie.name)
+            append("=")
+            append(cookie.value)
+            append("; Path=")
+            append(cookie.path)
+            append("; Domain=")
+            append(cookie.domain)
+            if (cookie.secure) append("; Secure")
+            if (cookie.httpOnly) append("; HttpOnly")
+        }
+        webCookieManager.setCookie(targetUrl, cookieValue)
+    }
+    webCookieManager.flush()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        webCookieManager.setAcceptThirdPartyCookies(webView, true)
+    }
+}
+
+private fun buildCookieTargetUrl(cookie: Cookie): String {
+    val scheme = if (cookie.secure) "https" else "http"
+    val domain = cookie.domain.trimStart('.')
+    return "$scheme://$domain"
+}

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/NetworkRecharge.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/NetworkRecharge.kt
@@ -1,0 +1,522 @@
+package com.ahu.ahutong.ui.screen.main
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ahu.ahutong.data.crawler.PayState
+import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
+import com.ahu.ahutong.ui.state.NetworkRechargePageState
+import com.ahu.ahutong.ui.state.NetworkRechargeUiData
+import com.ahu.ahutong.ui.state.NetworkRechargeViewModel
+import com.kyant.monet.a1
+import com.kyant.monet.n1
+import com.kyant.monet.withNight
+import kotlinx.coroutines.delay
+
+@Composable
+fun NetworkRecharge(
+    viewModel: NetworkRechargeViewModel = viewModel()
+) {
+    val pageState by viewModel.pageState.collectAsState()
+    val payState by viewModel.payState.collectAsState()
+    val focusManager = LocalFocusManager.current
+
+    var amount by remember { mutableStateOf("") }
+    var amountError by remember { mutableStateOf<String?>(null) }
+    var showDialog by remember { mutableStateOf(false) }
+    var password by remember { mutableStateOf("") }
+    var passwordError by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
+
+    LaunchedEffect(payState) {
+        when (payState) {
+            is PayState.Succeeded, is PayState.Failed -> {
+                delay(1200)
+                viewModel.resetPayState()
+            }
+
+            else -> Unit
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .systemBarsPadding(),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Text(
+            text = "网费充值",
+            modifier = Modifier.padding(24.dp, 32.dp),
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        when (val state = pageState) {
+            NetworkRechargePageState.Loading -> {
+                LoadingCard()
+            }
+
+            is NetworkRechargePageState.Error -> {
+                ErrorCard(
+                    message = state.message,
+                    onRetry = { viewModel.load() }
+                )
+            }
+
+            is NetworkRechargePageState.Ready -> {
+                NetworkAccountCard(data = state.data)
+                AmountCard(
+                    amount = amount,
+                    amountError = amountError,
+                    quickAmounts = state.data.quickAmounts,
+                    maxAmount = state.data.maxAmount,
+                    onAmountChange = { value ->
+                        if (value.isEmpty()) {
+                            amount = value
+                            amountError = null
+                            return@AmountCard
+                        }
+
+                        val regex = Regex("^\\d*\\.?\\d{0,2}$")
+                        if (regex.matches(value)) {
+                            amount = value
+                            amountError = null
+                        }
+                    },
+                    onQuickAmountClick = { quickAmount ->
+                        amount = normalizeQuickAmount(quickAmount)
+                        amountError = null
+                    },
+                    onDone = { focusManager.clearFocus() }
+                )
+
+                RechargeActionRow(
+                    payState = payState,
+                    onConfirm = {
+                        focusManager.clearFocus()
+                        val amountValue = amount.toDoubleOrNull()
+                        val maxAmount = state.data.maxAmount?.toDoubleOrNull()
+                        amountError = when {
+                            amount.isBlank() -> "请输入充值金额"
+                            amountValue == null || amountValue <= 0.0 -> "请输入有效金额"
+                            maxAmount != null && amountValue > maxAmount -> "单次最高可充值 ${state.data.maxAmount} 元"
+                            else -> null
+                        }
+                        if (amountError == null) {
+                            password = ""
+                            passwordError = null
+                            showDialog = true
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            containerColor = 100.n1 withNight 20.n1,
+            titleContentColor = 10.n1 withNight 90.n1,
+            onDismissRequest = { showDialog = false },
+            title = { Text("请输入校园卡密码") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = password,
+                        onValueChange = { input ->
+                            if (input.length <= 6 && input.all { it.isDigit() }) {
+                                password = input
+                                passwordError = null
+                            }
+                        },
+                        label = { Text("密码 (6位数字)", color = 40.n1 withNight 60.n1) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                        visualTransformation = PasswordVisualTransformation(),
+                        isError = passwordError != null,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = 10.n1 withNight 90.n1,
+                            unfocusedTextColor = 10.n1 withNight 90.n1,
+                            focusedBorderColor = 20.n1 withNight 80.n1
+                        )
+                    )
+                    passwordError?.let {
+                        Text(
+                            text = it,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (password.length == 6) {
+                            showDialog = false
+                            viewModel.pay(amount, password)
+                            password = ""
+                            passwordError = null
+                        } else {
+                            passwordError = "密码必须是6位数字"
+                        }
+                    }
+                ) {
+                    Text("确认", color = 10.n1 withNight 90.n1)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showDialog = false
+                        password = ""
+                        passwordError = null
+                    }
+                ) {
+                    Text("取消", color = 10.n1 withNight 90.n1)
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun LoadingCard() {
+    Box(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+            .clip(SmoothRoundedCornerShape(24.dp))
+            .background(100.n1 withNight 20.n1)
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(color = 30.n1 withNight 70.n1)
+    }
+}
+
+@Composable
+private fun ErrorCard(
+    message: String,
+    onRetry: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+            .clip(SmoothRoundedCornerShape(24.dp))
+            .background(100.n1 withNight 20.n1)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = message,
+            color = 10.n1 withNight 90.n1,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = "重试",
+            modifier = Modifier.clickable(onClick = onRetry),
+            color = 30.n1 withNight 70.n1,
+            style = MaterialTheme.typography.titleMedium
+        )
+    }
+}
+
+@Composable
+private fun NetworkAccountCard(
+    data: NetworkRechargeUiData
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+            .clip(SmoothRoundedCornerShape(24.dp))
+            .background(100.n1 withNight 20.n1)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = data.feeName,
+            style = MaterialTheme.typography.titleLarge
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "充值账号",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = data.account.ifBlank { "--" },
+                color = 10.n1 withNight 90.n1,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+        data.stats.forEach { (label, value) ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = label,
+                    color = 40.n1 withNight 60.n1,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = value.ifBlank { "--" },
+                    color = 10.n1 withNight 90.n1,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmountCard(
+    amount: String,
+    amountError: String?,
+    quickAmounts: List<String>,
+    maxAmount: String?,
+    onAmountChange: (String) -> Unit,
+    onQuickAmountClick: (String) -> Unit,
+    onDone: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+            .clip(SmoothRoundedCornerShape(24.dp))
+            .background(100.n1 withNight 20.n1)
+    ) {
+        Text(
+            text = "充值金额",
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        if (quickAmounts.isNotEmpty()) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                quickAmounts.forEach { quickAmount ->
+                    Text(
+                        text = quickAmount,
+                        modifier = Modifier
+                            .clip(SmoothRoundedCornerShape(16.dp))
+                            .background(90.a1 withNight 30.n1)
+                            .clickable { onQuickAmountClick(quickAmount) }
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        color = 10.n1 withNight 90.n1,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+
+        TextField(
+            value = amount,
+            onValueChange = onAmountChange,
+            modifier = Modifier.fillMaxWidth(),
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+            placeholder = {
+                Text(
+                    text = if (maxAmount.isNullOrBlank()) "请输入金额" else "请输入金额，单次最高 $maxAmount 元",
+                    color = 30.n1 withNight 70.n1
+                )
+            },
+            textStyle = TextStyle(fontSize = 16.sp, color = 10.n1 withNight 90.n1),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(onDone = { onDone() }),
+            singleLine = true
+        )
+
+        amountError?.let {
+            Text(
+                text = it,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+@Composable
+private fun RechargeActionRow(
+    payState: PayState,
+    onConfirm: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        Box(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .padding(16.dp)
+                .clip(SmoothRoundedCornerShape(32.dp))
+                .background(
+                    animateColorAsState(
+                        targetValue = when (payState) {
+                            PayState.Idle -> 90.a1 withNight 85.a1
+                            PayState.InProgress -> 70.a1 withNight 60.a1
+                            is PayState.Failed -> Color.Red
+                            is PayState.Succeeded -> 70.a1 withNight 60.a1
+                        }
+                    ).value
+                )
+                .animateContentSize(spring(stiffness = Spring.StiffnessLow))
+        ) {
+            when (payState) {
+                PayState.Idle -> {
+                    Text(
+                        text = "确认",
+                        modifier = Modifier
+                            .clickable(onClick = onConfirm)
+                            .padding(24.dp, 16.dp),
+                        color = 0.n1,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+
+                PayState.InProgress -> {
+                    Row(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = 100.n1,
+                            strokeWidth = 4.dp
+                        )
+                        Text(
+                            text = "支付中",
+                            color = 100.n1,
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+
+                is PayState.Failed -> {
+                    Row(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = 100.n1
+                        )
+                        Text(
+                            text = "充值失败：${payState.message}",
+                            color = 100.n1,
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+
+                is PayState.Succeeded -> {
+                    Row(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = 100.n1
+                        )
+                        Text(
+                            text = "充值成功！订单号：${payState.message}",
+                            color = 100.n1,
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun normalizeQuickAmount(raw: String): String {
+    return Regex("\\d+(?:\\.\\d{1,2})?")
+        .find(raw)
+        ?.value
+        ?: raw
+}

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/Tools.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/Tools.kt
@@ -161,6 +161,12 @@ fun Tools(
                         onClick = { navController.navigate(widget.route) }
                     )
                 }
+            ToolItem(
+                title = "网费充值",
+                iconId = R.drawable.ic_network_recharge,
+                tint = Color(0xFF1E88E5),
+                onClick = { navController.navigate("network_recharge") }
+            )
         }
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/CampusCard.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/CampusCard.kt
@@ -1,7 +1,6 @@
 package com.ahu.ahutong.ui.screen.main.home
 
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -43,9 +42,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -58,6 +56,7 @@ import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
 import com.ahu.ahutong.ui.state.DiscoveryViewModel
 import com.kyant.monet.n1
 import com.kyant.monet.withNight
+import java.util.Locale
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -148,34 +147,25 @@ private fun CardView(
                 ),
         ) {
             Column(
-                verticalArrangement = Arrangement.spacedBy(18.dp),
-                modifier = Modifier.padding(20.dp)
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(horizontal = 20.dp)
             ) {
                 Text(
                     text = stringResource(id = R.string.card_money),
                     fontWeight = FontWeight.Bold,
                     style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(vertical = 15.dp)
+                    modifier = Modifier.padding(bottom = 4.dp)
                 )
-                AnimatedContent(targetState = balance to transitionBalance) { (balance, transitionBalance) ->
-                    Text(
-                        text = buildAnnotatedString {
-                            withStyle(
-                                MaterialTheme.typography.titleLarge.toSpanStyle()
-                                    .copy(fontWeight = FontWeight.Bold)
-                            ) {
-                                append("¥ $balance")
-                            }
-//                        withStyle(
-//                            MaterialTheme.typography.titleSmall.toSpanStyle().copy(
-//                                color = 50.n1 withNight 80.n1
-//                            )
-//                        ) {
-//                            append(" + ¥ $transitionBalance")
-//                        }
-                        }
-                    )
-                }
+                Text(
+                    text = "¥ ${formatCampusCardBalance(balance)}",
+                    modifier = Modifier.fillMaxWidth(),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleLarge
+                )
             }
         }
 
@@ -207,7 +197,12 @@ private fun CardView(
 //                        Toast.makeText(context, "请安装支付宝", Toast.LENGTH_SHORT).show()
 //                    }
 
-                            navController.navigate("card_balance_deposit")
+                            val route = if (AHUCache.isCmbCardRechargePreferred()) {
+                                "cmb_card_recharge"
+                            } else {
+                                "card_balance_deposit"
+                            }
+                            navController.navigate(route)
                         }
                     } else {
                         Modifier
@@ -223,6 +218,11 @@ private fun CardView(
         }
     }
 
+}
+
+private fun formatCampusCardBalance(balance: Double): String {
+    if (!balance.isFinite()) return "--"
+    return String.format(Locale.CHINA, "%.2f", balance)
 }
 
 
@@ -313,7 +313,15 @@ private fun QRcodeView(balance: Double, onBack: () -> Unit) {
             }
         }
         Box(
-            modifier = Modifier.size(200.dp),
+            modifier = Modifier
+                .size(200.dp)
+                .clip(SmoothRoundedCornerShape(8.dp))
+                .background(Color.White)
+                .border(
+                    1.dp,
+                    Color.Gray,
+                    SmoothRoundedCornerShape(8.dp)
+                ),
             contentAlignment = Alignment.Center
         ) {
             if (finished) {
@@ -327,12 +335,7 @@ private fun QRcodeView(balance: Double, onBack: () -> Unit) {
                                 discoveryViewModel.loadQrCode()
                                 discoveryViewModel.refreshCardBalance()
                             }
-                            .clip(SmoothRoundedCornerShape(8.dp))
-                            .border(
-                                1.dp,
-                                Color.Gray,
-                                SmoothRoundedCornerShape(8.dp)
-                            )
+                            .padding(8.dp)
                     )
                 } ?: Text(
                     text = "加载失败"
@@ -343,7 +346,7 @@ private fun QRcodeView(balance: Double, onBack: () -> Unit) {
         }
 
         Text(
-            text = "¥ $balance",
+            text = "¥ ${formatCampusCardBalance(balance)}",
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(top = 12.dp)
@@ -374,6 +377,11 @@ private fun QRcodeView(balance: Double, onBack: () -> Unit) {
                                     )
                                 )
                                 .background(Color.White)
+                                .border(
+                                    1.dp,
+                                    Color.Gray,
+                                    SmoothRoundedCornerShape(24.dp)
+                                )
                                 .clickable {
                                     discoveryViewModel.loadQrCode()
                                     discoveryViewModel.refreshCardBalance()

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/HomeWeatherWidget.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/HomeWeatherWidget.kt
@@ -3,12 +3,8 @@ package com.ahu.ahutong.ui.screen.main.home
 import android.content.Context
 import android.location.Geocoder
 import android.location.LocationManager
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,11 +17,11 @@ import androidx.compose.ui.unit.sp
 import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.data.weather.WeatherApi
 import com.ahu.ahutong.data.weather.WeatherResponse
+import com.ahu.ahutong.ui.shape.SmoothRoundedCornerShape
 import com.kyant.monet.a1
 import com.kyant.monet.n1
 import com.kyant.monet.withNight
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
 
@@ -37,158 +33,183 @@ fun HomeWeatherWidget(onClick: () -> Unit) {
     val context = LocalContext.current
     var weather by remember { mutableStateOf<WeatherResponse?>(null) }
     var hasError by remember { mutableStateOf(false) }
-    val scope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) {
-        scope.launch {
-            try {
-                val city = withContext(Dispatchers.IO) { getCityFromLocation(context) }
-                weather = WeatherApi.API.getWeather(city = city)
-            } catch (_: Exception) {
-                hasError = true
+    LaunchedEffect(context) {
+        hasError = false
+        runCatching {
+            withContext(Dispatchers.IO) {
+                val city = getCityFromLocation(context)
+                WeatherApi.API.getWeather(city = city)
             }
+        }.onSuccess {
+            weather = it
+        }.onFailure {
+            hasError = true
         }
     }
 
-    AnimatedVisibility(
-        visible = weather != null && !hasError,
-        enter = fadeIn(),
-        exit = fadeOut()
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick),
+        shape = SmoothRoundedCornerShape(32.dp),
+        colors = CardDefaults.cardColors(containerColor = 100.n1 withNight 20.n1)
     ) {
-        val w = weather!!
-        val rainKeywords = listOf("雨", "雪", "雹")
-        val containsRain = { s: String? -> s != null && rainKeywords.any { s.contains(it) } }
-        val rainPossible = containsRain(w.weather) ||
-            w.forecast?.firstOrNull()?.let { containsRain(it.weatherDay) || containsRain(it.weatherNight) } == true ||
-            w.hourlyForecast?.take(6)?.any { containsRain(it.weather) } == true
-
-        val isSunny = w.weather?.let { it.contains("晴") && !it.contains("多云") } == true
-        val highUv = (w.uv ?: 0.0) >= 5.0
-
-        // Wind arrow: points in the direction wind is GOING
-        val windArrow = when (w.windDirection) {
-            "北风" -> "\u2193"
-            "南风" -> "\u2191"
-            "东风" -> "\u2190"
-            "西风" -> "\u2192"
-            "东北风" -> "\u2199"
-            "西北风" -> "\u2198"
-            "东南风" -> "\u2196"
-            "西南风" -> "\u2197"
-            else -> when {
-                (w.windDirection ?: "").contains("北") && (w.windDirection ?: "").contains("东") -> "\u2199"
-                (w.windDirection ?: "").contains("北") && (w.windDirection ?: "").contains("西") -> "\u2198"
-                (w.windDirection ?: "").contains("南") && (w.windDirection ?: "").contains("东") -> "\u2196"
-                (w.windDirection ?: "").contains("南") && (w.windDirection ?: "").contains("西") -> "\u2197"
-                (w.windDirection ?: "").contains("北") -> "\u2193"
-                (w.windDirection ?: "").contains("南") -> "\u2191"
-                (w.windDirection ?: "").contains("东") -> "\u2190"
-                (w.windDirection ?: "").contains("西") -> "\u2192"
-                else -> "\u2198"
-            }
-        }
-
-        Card(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp)
-                .clickable(onClick = onClick),
-            shape = RoundedCornerShape(20.dp),
-            colors = CardDefaults.cardColors(containerColor = 90.a1 withNight 30.a1)
+                .heightIn(min = 120.dp)
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Left: main weather info
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = listOfNotNull(w.district, w.city).firstOrNull() ?: "",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = 50.n1 withNight 80.n1
-                    )
-                    Spacer(Modifier.height(2.dp))
-                    Row(verticalAlignment = Alignment.Bottom) {
-                        Text(
-                            text = "${w.temperature?.toInt() ?: "--"}°",
-                            fontSize = 32.sp,
-                            fontWeight = FontWeight.Light,
-                            color = 0.n1 withNight 100.n1
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = w.weather ?: "",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = 0.n1 withNight 100.n1
-                        )
-                    }
-                    Spacer(Modifier.height(2.dp))
-                    if (w.windDirection != null || w.windPower != null) {
-                        Text(
-                            text = "$windArrow ${w.windDirection ?: ""} ${w.windPower ?: ""}".trim(),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = 50.n1 withNight 80.n1
-                        )
-                    }
-                    if (w.aqi != null) {
-                        val aqiEmoji = when (w.aqiLevel) {
-                            1 -> "\uD83D\uDFE2"
-                            2 -> "\uD83D\uDFE1"
-                            3 -> "\uD83D\uDFE0"
-                            4 -> "\uD83D\uDD34"
-                            5 -> "\uD83D\uDFE3"
-                            else -> "\u26AA"
+            val w = weather
+            when {
+                w != null && !hasError -> {
+                    val rainKeywords = listOf("雨", "雪", "雹")
+                    val containsRain = { s: String? -> s != null && rainKeywords.any { s.contains(it) } }
+                    val rainPossible = containsRain(w.weather) ||
+                        w.forecast?.firstOrNull()
+                            ?.let { containsRain(it.weatherDay) || containsRain(it.weatherNight) } == true ||
+                        w.hourlyForecast?.take(6)?.any { containsRain(it.weather) } == true
+
+                    val isSunny = w.weather?.let { it.contains("晴") && !it.contains("多云") } == true
+                    val highUv = (w.uv ?: 0.0) >= 5.0
+
+                    // Wind arrow: points in the direction wind is going.
+                    val windArrow = when (w.windDirection) {
+                        "北风" -> "\u2193"
+                        "南风" -> "\u2191"
+                        "东风" -> "\u2190"
+                        "西风" -> "\u2192"
+                        "东北风" -> "\u2199"
+                        "西北风" -> "\u2198"
+                        "东南风" -> "\u2196"
+                        "西南风" -> "\u2197"
+                        else -> when {
+                            (w.windDirection ?: "").contains("北") &&
+                                (w.windDirection ?: "").contains("东") -> "\u2199"
+                            (w.windDirection ?: "").contains("北") &&
+                                (w.windDirection ?: "").contains("西") -> "\u2198"
+                            (w.windDirection ?: "").contains("南") &&
+                                (w.windDirection ?: "").contains("东") -> "\u2196"
+                            (w.windDirection ?: "").contains("南") &&
+                                (w.windDirection ?: "").contains("西") -> "\u2197"
+                            (w.windDirection ?: "").contains("北") -> "\u2193"
+                            (w.windDirection ?: "").contains("南") -> "\u2191"
+                            (w.windDirection ?: "").contains("东") -> "\u2190"
+                            (w.windDirection ?: "").contains("西") -> "\u2192"
+                            else -> "\u2198"
                         }
-                        Text(
-                            text = "$aqiEmoji 空气${w.aqi} ${w.aqiCategory ?: ""}",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = 50.n1 withNight 80.n1
-                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = listOfNotNull(w.district, w.city).firstOrNull() ?: "",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = 50.n1 withNight 80.n1
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Row(verticalAlignment = Alignment.Bottom) {
+                                Text(
+                                    text = "${w.temperature?.toInt() ?: "--"}°",
+                                    fontSize = 32.sp,
+                                    fontWeight = FontWeight.Light,
+                                    color = 0.n1 withNight 100.n1
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text = w.weather ?: "",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = 0.n1 withNight 100.n1
+                                )
+                            }
+                            Spacer(Modifier.height(2.dp))
+                            if (w.windDirection != null || w.windPower != null) {
+                                Text(
+                                    text = "$windArrow ${w.windDirection ?: ""} ${w.windPower ?: ""}".trim(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = 50.n1 withNight 80.n1
+                                )
+                            }
+                            if (w.aqi != null) {
+                                val aqiEmoji = when (w.aqiLevel) {
+                                    1 -> "\uD83D\uDFE2"
+                                    2 -> "\uD83D\uDFE1"
+                                    3 -> "\uD83D\uDFE0"
+                                    4 -> "\uD83D\uDD34"
+                                    5 -> "\uD83D\uDFE3"
+                                    else -> "\u26AA"
+                                }
+                                Text(
+                                    text = "$aqiEmoji 空气${w.aqi} ${w.aqiCategory ?: ""}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = 50.n1 withNight 80.n1
+                                )
+                            }
+                        }
+
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(start = 12.dp)
+                        ) {
+                            if (rainPossible) {
+                                val pops = w.hourlyForecast?.take(6)?.mapNotNull { it.pop } ?: emptyList()
+                                val maxPop = if (pops.isNotEmpty()) pops.max() else 0
+                                val label = when {
+                                    maxPop >= 60 -> "务必带伞"
+                                    maxPop >= 40 -> "建议带伞"
+                                    maxPop > 0 -> "可能降雨"
+                                    else -> "带伞"
+                                }
+                                Text("\u2614", fontSize = 24.sp)
+                                Spacer(Modifier.height(2.dp))
+                                Text(
+                                    text = if (maxPop > 0) "${maxPop}%" else "--",
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = 80.a1 withNight 90.a1
+                                )
+                                Text(
+                                    text = label,
+                                    fontSize = 12.sp,
+                                    color = 50.n1 withNight 80.n1
+                                )
+                            } else if (isSunny && highUv) {
+                                Text("\u2600\uFE0F", fontSize = 24.sp)
+                                Spacer(Modifier.height(2.dp))
+                                Text(
+                                    text = "UV${w.uv?.toInt() ?: "--"}",
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = 80.a1 withNight 90.a1
+                                )
+                                Text(
+                                    text = "防晒",
+                                    fontSize = 12.sp,
+                                    color = 50.n1 withNight 80.n1
+                                )
+                            }
+                        }
                     }
                 }
-
-                // Right: tips
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(start = 12.dp)
-                ) {
-                    if (rainPossible) {
-                        val pops = w.hourlyForecast?.take(6)?.mapNotNull { it.pop } ?: emptyList()
-                        val maxPop = if (pops.isNotEmpty()) pops.max() else 0
-                        val label = when {
-                            maxPop >= 60 -> "务必带伞"
-                            maxPop >= 40 -> "建议带伞"
-                            maxPop > 0 -> "可能降雨"
-                            else -> "带伞"
-                        }
-                        Text("\u2614", fontSize = 24.sp)
-                        Spacer(Modifier.height(2.dp))
-                        Text(
-                            text = if (maxPop > 0) "${maxPop}%" else "--",
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = 80.a1 withNight 90.a1
-                        )
-                        Text(
-                            text = label,
-                            fontSize = 12.sp,
-                            color = 50.n1 withNight 80.n1
-                        )
-                    } else if (isSunny && highUv) {
-                        Text("\u2600\uFE0F", fontSize = 24.sp)
-                        Spacer(Modifier.height(2.dp))
-                        Text(
-                            text = "UV${w.uv?.toInt() ?: "--"}",
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = 80.a1 withNight 90.a1
-                        )
-                        Text(
-                            text = "防晒",
-                            fontSize = 12.sp,
-                            color = 50.n1 withNight 80.n1
-                        )
-                    }
+                hasError -> {
+                    Text(
+                        text = "天气暂不可用",
+                        textAlign = TextAlign.Center,
+                        color = 50.n1 withNight 80.n1
+                    )
+                }
+                else -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = 70.a1 withNight 85.a1
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/HomeWidgetEditor.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/HomeWidgetEditor.kt
@@ -106,8 +106,7 @@ fun HomeWidgetSlotLayout(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(IntrinsicSize.Min)
-                .padding(horizontal = 16.dp),
+                .height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             CampusCard(
@@ -166,9 +165,7 @@ fun HomeWidgetSlotLayout(
             val hasRowContent = slots.getOrNull(leftSlot - 1) != null || slots.getOrNull(rightSlot - 1) != null
             if (isEditing || hasRowContent) {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     HomeWidgetSlot(

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/TodayCourseList.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/main/home/TodayCourseList.kt
@@ -74,10 +74,13 @@ fun TodayCourseList(
         return
     }
 
-    val currentCourseIndex = todayCourses.indexOfLast {
+    val activeCourseIndex = todayCourses.indexOfFirst {
+        currentMinutes in ScheduleViewModel.getCourseTimeRangeInMinutes(it)
+    }
+    val timelineProgressIndex = todayCourses.indexOfLast {
         val range = ScheduleViewModel.getCourseTimeRangeInMinutes(it)
-        currentMinutes > range.first
-    }.coerceAtLeast(0)
+        currentMinutes >= range.first
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -97,64 +100,67 @@ fun TodayCourseList(
                 val onColor = 50.a1 withNight 90.a1
                 val activatedColor = 90.a1
                 drawBehind {
+                    val rowHeight = 40.dp.toPx()
+                    val markerX = 4.dp.toPx()
+                    val markerRadius = 4.dp.toPx()
+                    val markerStroke = 2.dp.toPx()
+                    val activeBackgroundStart = 0f
+                    if (activeCourseIndex >= 0) {
+                        drawRoundRect(
+                            color = activatedColor,
+                            topLeft = Offset(
+                                activeBackgroundStart,
+                                rowHeight * activeCourseIndex - 12.dp.toPx()
+                            ),
+                            size = Size(
+                                size.width + 8.dp.toPx(),
+                                48.dp.toPx()
+                            ),
+                            cornerRadius = CornerRadius(24.dp.toPx())
+                        )
+                    }
                     drawLine(
                         color = offColor,
-                        start = Offset(4.dp.toPx(), 12.dp.toPx()),
-                        end = Offset(4.dp.toPx(), size.height - 12.dp.toPx()),
+                        start = Offset(markerX, 12.dp.toPx()),
+                        end = Offset(markerX, size.height - 12.dp.toPx()),
                         strokeWidth = 1.dp.toPx(),
                         pathEffect = PathEffect.dashPathEffect(
                             intervals = floatArrayOf(4.dp.toPx(), 4.dp.toPx()),
                             phase = 8.dp.toPx()
                         )
                     )
-                    drawLine(
-                        color = onColor,
-                        start = Offset(4.dp.toPx(), 12.dp.toPx()),
-                        end = Offset(
-                            4.dp.toPx(),
-                            40.dp.toPx() * currentCourseIndex + 12.dp.toPx()
-                        ),
-                        strokeWidth = 2.dp.toPx(),
-                        pathEffect = PathEffect.dashPathEffect(
-                            intervals = floatArrayOf(6.dp.toPx(), 4.dp.toPx()),
-                            phase = 4.dp.toPx()
-                        )
-                    )
-                    repeat(currentCourseIndex + 1) {
-                        drawCircle(
+                    if (timelineProgressIndex >= 0) {
+                        drawLine(
                             color = onColor,
-                            radius = 4.dp.toPx(),
-                            center = Offset(
-                                4.dp.toPx(),
-                                40.dp.toPx() * it + 12.dp.toPx()
+                            start = Offset(markerX, 12.dp.toPx()),
+                            end = Offset(
+                                markerX,
+                                rowHeight * timelineProgressIndex + 12.dp.toPx()
+                            ),
+                            strokeWidth = 2.dp.toPx(),
+                            pathEffect = PathEffect.dashPathEffect(
+                                intervals = floatArrayOf(6.dp.toPx(), 4.dp.toPx()),
+                                phase = 4.dp.toPx()
                             )
                         )
                     }
-                    repeat(todayCourses.size - currentCourseIndex - 1) {
-                        drawCircle(
-                            color = offColor,
-                            radius = 2.dp.toPx(),
-                            center = Offset(
-                                4.dp.toPx(),
-                                40.dp.toPx() * (currentCourseIndex + 1 + it) + 12.dp.toPx()
-                            ),
-                            style = Stroke(2.dp.toPx())
-                        )
-                    }
-                    val currentCourseRange =
-                        ScheduleViewModel.getCourseTimeRangeInMinutes(
-                            todayCourses[currentCourseIndex]
-                        )
-                    if (currentMinutes in currentCourseRange) {
-                        drawRoundRect(
-                            color = activatedColor,
-                            topLeft = Offset(
-                                0f,
-                                40.dp.toPx() * currentCourseIndex - 12.dp.toPx()
-                            ),
-                            size = Size(size.width + 8.dp.toPx(), 48.dp.toPx()),
-                            cornerRadius = CornerRadius(24.dp.toPx())
-                        )
+                    todayCourses.indices.forEach { index ->
+                        val center = Offset(markerX, rowHeight * index + 12.dp.toPx())
+                        val color = if (index <= timelineProgressIndex) onColor else offColor
+                        if (index == activeCourseIndex) {
+                            drawCircle(
+                                color = color,
+                                radius = markerRadius,
+                                center = center
+                            )
+                        } else {
+                            drawCircle(
+                                color = color,
+                                radius = markerRadius,
+                                center = center,
+                                style = Stroke(markerStroke)
+                            )
+                        }
                     }
                 }
             },

--- a/app/src/main/java/com/ahu/ahutong/ui/screen/settings/Preferences.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/screen/settings/Preferences.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ahu.ahutong.R
+import com.ahu.ahutong.data.dao.AHUCache
 import com.ahu.ahutong.notification.CourseReminderCapability
 import com.ahu.ahutong.notification.CourseReminderNotifier
 import com.ahu.ahutong.notification.CourseReminderScheduler
@@ -69,6 +70,7 @@ fun Preferences() {
     val preferencesViewModel: PreferencesViewModel = hiltViewModel()
     val context = LocalContext.current
     var isRequestingPermission by remember { mutableStateOf(false) }
+    var useCmbCardRecharge by remember { mutableStateOf(AHUCache.isCmbCardRechargePreferred()) }
 
     val showQRCode by preferencesViewModel.showQRCode.collectAsState()
     val useLiquidGlass by preferencesViewModel.useLiquidGlass.collectAsState()
@@ -132,6 +134,50 @@ fun Preferences() {
             }
         }
         */
+
+        Column(
+            modifier =
+                Modifier
+                    .clip(SmoothRoundedCornerShape(16.dp))
+                    .background(cardColor)
+                    .clickable {
+                        val enabled = !useCmbCardRecharge
+                        useCmbCardRecharge = enabled
+                        AHUCache.setCmbCardRechargePreferred(enabled)
+                    }
+                    .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(text = "充值", style = MaterialTheme.typography.headlineSmall)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(SmoothRoundedCornerShape(8.dp))
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(text = "总是使用招商银行充值")
+                    Text(
+                        text = "开启后首页校园卡充值会直接进入招商银行充值",
+                        color = 50.n1 withNight 80.n1,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                LiquidToggle(
+                    selected = { useCmbCardRecharge },
+                    onSelect = { enabled ->
+                        useCmbCardRecharge = enabled
+                        AHUCache.setCmbCardRechargePreferred(enabled)
+                    },
+                    backdrop = backdrop
+                )
+            }
+        }
 
         Column(
             modifier =

--- a/app/src/main/java/com/ahu/ahutong/ui/state/NetworkRechargeViewModel.kt
+++ b/app/src/main/java/com/ahu/ahutong/ui/state/NetworkRechargeViewModel.kt
@@ -1,0 +1,517 @@
+package com.ahu.ahutong.ui.state
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ahu.ahutong.data.AHUResponse
+import com.ahu.ahutong.data.crawler.PayState
+import com.ahu.ahutong.data.crawler.api.ycard.YcardApi
+import com.ahu.ahutong.data.crawler.manager.TokenManager
+import com.ahu.ahutong.data.crawler.utils.generateNonce
+import com.ahu.ahutong.data.crawler.utils.getTimestamp
+import com.ahu.ahutong.data.crawler.utils.sha256
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.ResponseBody
+import retrofit2.Response
+
+private const val NETWORK_FEE_ITEM_ID = "431"
+private const val NETWORK_FEE_ENTRY_APP_ID = "75"
+private const val YCARD_ORIGIN = "https://ycard.ahu.edu.cn"
+private const val NETWORK_ENTRY_REFERER = "https://ycard.ahu.edu.cn/plat/dating?index=1"
+
+private val networkEntryClient by lazy {
+    YcardApi.okHttpClient.newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
+}
+
+data class NetworkFeeItemPageResponse(
+    val msg: String?,
+    val code: Int,
+    val view: String?,
+    val feeitem: NetworkFeeItem?
+)
+
+data class NetworkFeeItem(
+    val name: String?,
+    val layout: String?,
+    val maxmoney: String?,
+    val daymaxmoney: String?,
+    val billing_unit: String?
+)
+
+data class NetworkFeeInfoResponse(
+    val msg: String?,
+    val code: Int,
+    val map: NetworkFeeInfoMap?
+)
+
+data class NetworkFeeInfoMap(
+    val showData: Map<String, String>?,
+    val data: NetworkThirdPartyData?
+)
+
+data class NetworkThirdPartyData(
+    val state_time: String?,
+    val state_memo: String?,
+    val balance: String?,
+    val use_time: String?,
+    val tsmAbstract: String?,
+    val use_money: String?,
+    val use_flow: String?,
+    val account: String?,
+    val user_state: String?,
+    val start_date: String?
+)
+
+private data class NetworkOrderResponse(
+    val code: Int,
+    val success: Boolean,
+    val data: NetworkOrderData?,
+    val msg: String?
+)
+
+private data class NetworkAccountPayInfoResponse(
+    val code: Int,
+    val success: Boolean,
+    val data: NetworkAccountPayInfoData?,
+    val msg: String?
+)
+
+private data class NetworkFinalPayResponse(
+    val code: Int,
+    val success: Boolean,
+    val data: String?,
+    val msg: String?
+)
+
+private data class NetworkOrderData(
+    val orderid: String
+)
+
+private data class NetworkAccountPayInfoData(
+    val passwordMap: Map<String, String>?
+)
+
+private data class ThirdDataResponse(
+    val msg: String?,
+    val code: Int
+)
+
+data class NetworkRechargeUiData(
+    val feeName: String,
+    val account: String,
+    val stats: List<Pair<String, String>>,
+    val quickAmounts: List<String>,
+    val maxAmount: String?,
+    val thirdPartyData: NetworkThirdPartyData
+)
+
+sealed class NetworkRechargePageState {
+    object Loading : NetworkRechargePageState()
+    data class Ready(val data: NetworkRechargeUiData) : NetworkRechargePageState()
+    data class Error(val message: String) : NetworkRechargePageState()
+}
+
+class NetworkRechargeViewModel : ViewModel() {
+
+    private val _pageState = MutableStateFlow<NetworkRechargePageState>(NetworkRechargePageState.Loading)
+    val pageState: StateFlow<NetworkRechargePageState> = _pageState.asStateFlow()
+
+    private val _payState = MutableStateFlow<PayState>(PayState.Idle)
+    val payState: StateFlow<PayState> = _payState.asStateFlow()
+
+    fun load() {
+        viewModelScope.launch {
+            _pageState.value = NetworkRechargePageState.Loading
+            _payState.value = PayState.Idle
+            val token = withContext(Dispatchers.IO) { TokenManager.awaitToken() }
+            if (token.isNullOrBlank()) {
+                _pageState.value = NetworkRechargePageState.Error("校园卡登录凭证暂未就绪，请稍后重试")
+                return@launch
+            }
+
+            runCatching {
+                warmUpNetworkRechargeEntry(token)
+                fetchSelectState()
+                val feeItem = fetchFeeItem()
+                val feeItemData = feeItem.data
+                if (feeItem.code != 0 || feeItemData == null) {
+                    throw IllegalStateException(feeItem.msg ?: "网费充值配置加载失败")
+                }
+                val info = fetchNetworkInfo()
+                val infoData = info.data
+                if (infoData == null) {
+                    throw IllegalStateException(info.msg ?: "未获取到网费账户信息")
+                }
+                val quickAmounts = feeItemData.layout
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotBlank() }
+                    .orEmpty()
+                val showData = infoData.showData
+                val thirdPartyData = infoData.thirdPartyData
+                if (thirdPartyData == null) {
+                    throw IllegalStateException("网费账户数据不完整")
+                }
+                val account = thirdPartyData.account.orEmpty()
+                val priorityKeys = setOf("用户状态", "储值余额", "本期已使用费用", "本期已使用时长", "本期已使用流量")
+                val orderedStats = mutableListOf<Pair<String, String>>().apply {
+                    showData["用户状态"]?.let { add("用户状态" to it) }
+                    showData["储值余额"]?.let { add("储值余额" to it) }
+                    showData["本期已使用费用"]?.let { add("本期已使用费用" to it) }
+                    showData["本期已使用时长"]?.let { add("本期已使用时长" to it) }
+                    showData["本期已使用流量"]?.let { add("本期已使用流量" to it) }
+                    addAll(
+                        showData.entries
+                            .filterNot { it.key in priorityKeys }
+                            .map { it.key to it.value }
+                    )
+                }
+
+                _pageState.value = NetworkRechargePageState.Ready(
+                    NetworkRechargeUiData(
+                        feeName = feeItemData.name ?: "网费充值",
+                        account = account,
+                        stats = orderedStats,
+                        quickAmounts = quickAmounts,
+                        maxAmount = feeItemData.maxmoney ?: feeItemData.daymaxmoney,
+                        thirdPartyData = thirdPartyData
+                    )
+                )
+            }.onFailure { throwable ->
+                Log.e("NetworkRechargeViewModel", "Failed to load network recharge info", throwable)
+                _pageState.value = NetworkRechargePageState.Error(
+                    throwable.message ?: "网费充值信息加载失败"
+                )
+            }
+        }
+    }
+
+    fun pay(amount: String, password: String) {
+        if (amount.toDoubleOrNull() ?: 0.0 <= 0) {
+            _payState.value = PayState.Failed("请输入有效金额")
+            return
+        }
+        if (password.length != 6 || !password.all { it.isDigit() }) {
+            _payState.value = PayState.Failed("请输入6位校园卡密码")
+            return
+        }
+        val page = (_pageState.value as? NetworkRechargePageState.Ready)?.data
+        if (page == null) {
+            _payState.value = PayState.Failed("网费账户信息尚未加载完成")
+            return
+        }
+
+        _payState.value = PayState.InProgress
+        viewModelScope.launch {
+            try {
+                val orderResult = getPaymentOrder(amount, page.thirdPartyData)
+                if (orderResult.code != 0 || orderResult.data == null) {
+                    _payState.value = PayState.Failed(orderResult.msg ?: "创建订单失败")
+                    return@launch
+                }
+                val orderId = orderResult.data.orderid
+
+                val accountPayInfoResult = getAccountPayInfo(orderId)
+                val passwordMap = accountPayInfoResult.data?.passwordMap
+                if (accountPayInfoResult.code != 0 || passwordMap.isNullOrEmpty()) {
+                    _payState.value = PayState.Failed(accountPayInfoResult.msg ?: "获取支付信息失败")
+                    return@launch
+                }
+
+                val (uuid, mapString) = passwordMap.entries.first()
+                val keymap = buildPasswordCipherMap(mapString)
+                val cipherText = password.map { ch ->
+                    keymap[ch] ?: error("无效的校园卡密码映射")
+                }.joinToString("")
+
+                val finalResponse = executeFinalPay(
+                    orderId = orderId,
+                    password = cipherText,
+                    uuid = uuid
+                )
+
+                if (finalResponse.code == 0) {
+                    _payState.value = PayState.Succeeded(orderId)
+                } else {
+                    _payState.value = PayState.Failed(finalResponse.msg ?: "网费充值失败")
+                }
+            } catch (t: Throwable) {
+                Log.e("NetworkRechargeViewModel", "Failed to pay network recharge", t)
+                _payState.value = PayState.Failed(t.message ?: "网费充值失败，请稍后重试")
+            }
+        }
+    }
+
+    fun resetPayState() {
+        _payState.value = PayState.Idle
+    }
+
+    private suspend fun warmUpNetworkRechargeEntry(token: String) {
+        withContext(Dispatchers.IO) {
+            val url = "$YCARD_ORIGIN/charge/feeitem/toAppitem".toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("feeitemid", NETWORK_FEE_ITEM_ID)
+                .addQueryParameter("appId", NETWORK_FEE_ENTRY_APP_ID)
+                .addQueryParameter("loginFrom", "h5")
+                .addQueryParameter("synAccessSource", "h5")
+                .addQueryParameter("synjones-auth", token)
+                .build()
+            val request = Request.Builder()
+                .url(url)
+                .header("Referer", NETWORK_ENTRY_REFERER)
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                .header("User-Agent", "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36")
+                .get()
+                .build()
+            networkEntryClient.newCall(request).execute().use { response ->
+                val accepted = response.code in 300..399 || response.isSuccessful
+                if (!accepted) {
+                    throw IllegalStateException("网费入口预热失败: ${response.code}")
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchSelectState() {
+        val responseWrapper = AHUResponse<Unit>()
+        val formBody = FormBody.Builder()
+            .add("feeitemid", NETWORK_FEE_ITEM_ID)
+            .add("type", "select")
+            .add("level", "0")
+            .build()
+        val result = executeThirdData(formBody, responseWrapper, "网费充值入口预热失败")
+        if (result.code != 0) {
+            throw IllegalStateException(result.msg ?: "网费充值入口预热失败")
+        }
+    }
+
+    private suspend fun fetchFeeItem(): AHUResponse<NetworkFeeItem> {
+        val responseWrapper = AHUResponse<NetworkFeeItem>()
+        val response = YcardApi.API.getSingleFeeItem(NETWORK_FEE_ITEM_ID)
+        return parseJsonResponse(response, responseWrapper) { body ->
+            val parsed = Gson().fromJson(body, NetworkFeeItemPageResponse::class.java)
+            if (parsed.code == 200 && parsed.feeitem != null) {
+                responseWrapper.code = 0
+                responseWrapper.msg = "success"
+                responseWrapper.data = parsed.feeitem
+            } else {
+                responseWrapper.code = -1
+                responseWrapper.msg = parsed.msg ?: "网费充值配置加载失败"
+            }
+        }
+    }
+
+    private suspend fun fetchNetworkInfo(): AHUResponse<NetworkFeeInfoPayload> {
+        val responseWrapper = AHUResponse<NetworkFeeInfoPayload>()
+        val formBody = FormBody.Builder()
+            .add("feeitemid", NETWORK_FEE_ITEM_ID)
+            .add("type", "IEC")
+            .add("level", "0")
+            .build()
+        val response = YcardApi.API.getFeeItemThirdData(formBody)
+        return parseJsonResponse(response, responseWrapper) { body ->
+            val parsed = Gson().fromJson(body, NetworkFeeInfoResponse::class.java)
+            val map = parsed.map
+            if (parsed.code == 200 && map?.data != null) {
+                responseWrapper.code = 0
+                responseWrapper.msg = "success"
+                responseWrapper.data = NetworkFeeInfoPayload(
+                    showData = map.showData.orEmpty(),
+                    thirdPartyData = map.data
+                )
+            } else {
+                responseWrapper.code = -1
+                responseWrapper.msg = parsed.msg ?: "网费账户信息加载失败"
+            }
+        }
+    }
+
+    private suspend fun getPaymentOrder(
+        amount: String,
+        thirdPartyData: NetworkThirdPartyData
+    ): AHUResponse<NetworkOrderData> {
+        val responseWrapper = AHUResponse<NetworkOrderData>()
+        val formBody = buildSignedFormBody(
+            linkedMapOf(
+                "feeitemid" to NETWORK_FEE_ITEM_ID,
+                "tranamt" to amount,
+                "flag" to "choose",
+                "source" to "app",
+                "paystep" to "0",
+                "abstracts" to "",
+                "redirect_url" to "https://ycard.ahu.edu.cn/plat",
+                "third_party" to Gson().toJson(thirdPartyData)
+            )
+        )
+        val response = YcardApi.API.pay(formBody)
+        return parseJsonResponse(response, responseWrapper) { body ->
+            val parsed = Gson().fromJson(body, NetworkOrderResponse::class.java)
+            if (parsed.code == 200 && parsed.data != null) {
+                responseWrapper.code = 0
+                responseWrapper.msg = "success"
+                responseWrapper.data = parsed.data
+            } else {
+                responseWrapper.code = -1
+                responseWrapper.msg = parsed.msg
+            }
+        }
+    }
+
+    private suspend fun getAccountPayInfo(orderId: String): AHUResponse<NetworkAccountPayInfoData> {
+        val responseWrapper = AHUResponse<NetworkAccountPayInfoData>()
+        val formBody = buildSignedFormBody(
+            linkedMapOf(
+                "paytypeid" to "64",
+                "paytype" to "ACCOUNTTSM",
+                "paystep" to "2",
+                "orderid" to orderId
+            )
+        )
+        val response = YcardApi.API.pay(formBody)
+        return parseJsonResponse(response, responseWrapper) { body ->
+            val parsed = Gson().fromJson(body, NetworkAccountPayInfoResponse::class.java)
+            if (parsed.code == 200 && parsed.data?.passwordMap?.isNotEmpty() == true) {
+                responseWrapper.code = 0
+                responseWrapper.msg = "success"
+                responseWrapper.data = parsed.data
+            } else {
+                responseWrapper.code = -1
+                responseWrapper.msg = parsed.msg
+            }
+        }
+    }
+
+    private suspend fun executeFinalPay(
+        orderId: String,
+        password: String,
+        uuid: String
+    ): AHUResponse<String> {
+        val responseWrapper = AHUResponse<String>()
+        val formBody = buildSignedFormBody(
+            linkedMapOf(
+                "orderid" to orderId,
+                "paystep" to "2",
+                "paytype" to "ACCOUNTTSM",
+                "paytypeid" to "64",
+                "userAgent" to "h5",
+                "ccctype" to "000",
+                "password" to password,
+                "uuid" to uuid,
+                "isWX" to "0"
+            )
+        )
+        val response = YcardApi.API.pay(formBody)
+        return parseJsonResponse(response, responseWrapper) { body ->
+            val parsed = Gson().fromJson(body, NetworkFinalPayResponse::class.java)
+            if (parsed.code == 200 && parsed.success && !parsed.data.isNullOrBlank()) {
+                responseWrapper.code = 0
+                responseWrapper.msg = "success"
+                responseWrapper.data = parsed.data
+            } else {
+                responseWrapper.code = -1
+                responseWrapper.msg = parsed.msg
+            }
+        }
+    }
+
+    private suspend fun <T> parseJsonResponse(
+        response: Response<ResponseBody>,
+        wrapper: AHUResponse<T>,
+        parser: (String) -> Unit
+    ): AHUResponse<T> {
+        return withContext(Dispatchers.IO) {
+            try {
+                if (!response.isSuccessful) {
+                    wrapper.code = response.code()
+                    wrapper.msg = "请求接口失败: ${response.message()}"
+                    return@withContext wrapper
+                }
+                val body = response.body()?.string()
+                if (body.isNullOrBlank()) {
+                    wrapper.code = -1
+                    wrapper.msg = "服务器返回内容为空"
+                    return@withContext wrapper
+                }
+                parser(body)
+                wrapper
+            } catch (t: Throwable) {
+                wrapper.code = -1
+                wrapper.msg = t.message ?: "发生未知错误"
+                wrapper
+            }
+        }
+    }
+
+    private suspend fun executeThirdData(
+        formBody: FormBody,
+        wrapper: AHUResponse<Unit>,
+        errorMessage: String
+    ): AHUResponse<Unit> {
+        val response = YcardApi.API.getFeeItemThirdData(formBody)
+        return parseJsonResponse(response, wrapper) { body ->
+            val responseBody = Gson().fromJson(body, ThirdDataResponse::class.java)
+            if (responseBody.code == 200) {
+                wrapper.code = 0
+                wrapper.msg = "success"
+                wrapper.data = Unit
+            } else {
+                wrapper.code = -1
+                wrapper.msg = responseBody.msg ?: errorMessage
+            }
+        }
+    }
+
+    private fun buildSignedFormBody(params: LinkedHashMap<String, String>): FormBody {
+        val appId = "56321"
+        val timestamp = getTimestamp()
+        val signType = "SHA256"
+        val nonce = generateNonce()
+        val signParams = linkedMapOf(
+            "APP_ID" to appId,
+            "NONCE" to nonce,
+            "SIGN_TYPE" to signType,
+            "TIMESTAMP" to timestamp
+        ).apply {
+            params.filterValues { it.isNotEmpty() }
+                .toSortedMap()
+                .forEach { (key, value) -> put(key, value) }
+        }
+        val signSource = signParams.entries.joinToString("&") { (key, value) -> "$key=$value" } +
+                "&SECRET_KEY=0osTIhce7uPvDKHz6aa67bhCukaKoYl4"
+        val sign = sha256(signSource).uppercase()
+
+        val builder = FormBody.Builder()
+        params.forEach { (key, value) -> builder.add(key, value) }
+        builder.add("APP_ID", appId)
+        builder.add("TIMESTAMP", timestamp)
+        builder.add("SIGN_TYPE", signType)
+        builder.add("NONCE", nonce)
+        builder.add("SIGN", sign)
+        return builder.build()
+    }
+
+    private fun buildPasswordCipherMap(mapString: String): Map<Char, Char> {
+        require(mapString.length == 10) { "无效的密码映射表" }
+        val plainDigits = "0123456789"
+        return mapString.mapIndexed { index, cipherDigit ->
+            cipherDigit to plainDigits[index]
+        }.toMap()
+    }
+}
+
+data class NetworkFeeInfoPayload(
+    val showData: Map<String, String>,
+    val thirdPartyData: NetworkThirdPartyData?
+)

--- a/app/src/main/res/drawable/ic_network_recharge.xml
+++ b/app/src/main/res/drawable/ic_network_recharge.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,5h12c1.66,0 3,1.34 3,3v7c0,1.66 -1.34,3 -3,3h-4.25l1.25,2h1.5c0.55,0 1,0.45 1,1s-0.45,1 -1,1h-9c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1H9l1.25,-2H6c-1.66,0 -3,-1.34 -3,-3V8c0,-1.66 1.34,-3 3,-3zM6,7c-0.55,0 -1,0.45 -1,1v7c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1V8c0,-0.55 -0.45,-1 -1,-1H6z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10.5,9.5L8,12l2.5,2.5v-1.5h3v1.5L16,12l-2.5,-2.5V11h-3z" />
+</vector>


### PR DESCRIPTION
**PR 说明**

本次改动接入了校园卡招商银行充值与网费充值能力，并补充了相关入口、偏好设置和界面调整。

**改动内容**

- 新增招商银行校园卡充值页，通过 WebView 走官方跳转链路。
- 校园卡充值页新增“招商银行充值点这里”入口，并提供弹窗选择：
  - `以后都用`：保存默认使用招商银行充值。
  - `仅本次`：只本次进入招商银行充值。
  - `取消`：关闭弹窗。
- 偏好设置新增“总是使用招商银行充值”开关，可关闭默认招行充值，避免只能开不能关。
- 首页校园卡“充值”按钮根据偏好决定进入原充值页或招商银行充值页。
- 新增网费充值入口，放到“小工具”页。
- 新增网费充值页面，按 HAR 链路接入网费账户信息查询、下单和校园卡账户支付。
- 调整首页校园卡余额展示，缩小“校园卡余额”和金额之间的空隙。
- 招商银行 WebView 注入轻量 CSS，使页面视觉更贴近 App 风格。

**验证方式**

- `git diff --check`
- `adb devices`
  - 检测到设备：`MR9PGE6T855TVW7L`
- `.\gradlew.bat :app:assembleDebug`
  - 构建成功，复用现有 Rust SO
- `.\gradlew.bat :app:installDebug`
  - 安装成功
- `adb shell am start -n com.ahu.ahutong/.MainActivity`
  - 启动成功，进程存在

**影响范围**

- 校园卡充值入口与默认充值偏好。
- 小工具页入口列表。
- 新增网费充值流程。
- WebView Cookie/token 同步与招行充值跳转。

